### PR TITLE
fix : 아이콘 버튼 터치 영역 48x48로 확대 #157

### DIFF
--- a/lib/features/game/presentation/pages/game_page.dart
+++ b/lib/features/game/presentation/pages/game_page.dart
@@ -1006,18 +1006,25 @@ class _GamePageState extends ConsumerState<GamePage> {
               ),
             ],
           ),
-          // 우측: info 버튼 (24x24)
+          // 우측: info 버튼 (터치 영역 48x48)
           Align(
             alignment: Alignment.centerRight,
             child: GestureDetector(
               onTap: _showGameRulesDialog,
-              child: SvgPicture.asset(
-                'assets/icons/icon_info.svg',
-                width: 24.w,
-                height: 24.w,
-                colorFilter: ColorFilter.mode(
-                  _isDarkMode ? AppColors.black200 : AppColors.black800,
-                  BlendMode.srcIn,
+              behavior: HitTestBehavior.opaque,
+              child: SizedBox(
+                width: 48.w,
+                height: 48.w,
+                child: Center(
+                  child: SvgPicture.asset(
+                    'assets/icons/icon_info.svg',
+                    width: 24.w,
+                    height: 24.w,
+                    colorFilter: ColorFilter.mode(
+                      _isDarkMode ? AppColors.black200 : AppColors.black800,
+                      BlendMode.srcIn,
+                    ),
+                  ),
                 ),
               ),
             ),

--- a/lib/features/session/presentation/pages/home_page.dart
+++ b/lib/features/session/presentation/pages/home_page.dart
@@ -373,13 +373,21 @@ class HomePage extends ConsumerWidget {
                       onTap: () {
                         context.push(RoutePaths.settings);
                       },
-                      child: SvgPicture.asset(
-                        'assets/icons/icon_setting_1.svg',
-                        width: 24.w,
-                        height: 24.h,
-                        colorFilter: const ColorFilter.mode(
-                          AppColors.black800,
-                          BlendMode.srcIn,
+                      behavior: HitTestBehavior.opaque,
+                      child: SizedBox(
+                        width: 48.w,
+                        height: 48.w,
+                        child: Align(
+                          alignment: Alignment.centerRight,
+                          child: SvgPicture.asset(
+                            'assets/icons/icon_setting_1.svg',
+                            width: 24.w,
+                            height: 24.w,
+                            colorFilter: const ColorFilter.mode(
+                              AppColors.black800,
+                              BlendMode.srcIn,
+                            ),
+                          ),
                         ),
                       ),
                     ),

--- a/lib/features/session/presentation/pages/waiting_room_page.dart
+++ b/lib/features/session/presentation/pages/waiting_room_page.dart
@@ -835,32 +835,43 @@ class _WaitingRoomPageState extends ConsumerState<WaitingRoomPage>
         GestureDetector(
           onTap: _showGameRulesDialog,
           behavior: HitTestBehavior.opaque,
-          child: SvgPicture.asset(
-            'assets/icons/icon_info.svg',
-            width: 24.w,
-            height: 24.w,
-            colorFilter: ColorFilter.mode(
-              isDark ? AppColors.black200 : AppColors.black800,
-              BlendMode.srcIn,
+          child: SizedBox(
+            width: 48.w,
+            height: 48.w,
+            child: Center(
+              child: SvgPicture.asset(
+                'assets/icons/icon_info.svg',
+                width: 24.w,
+                height: 24.w,
+                colorFilter: ColorFilter.mode(
+                  isDark ? AppColors.black200 : AppColors.black800,
+                  BlendMode.srcIn,
+                ),
+              ),
             ),
           ),
         ),
-        SizedBox(width: AppSpacing.horizontal12),
         GestureDetector(
           onTap: () =>
               context.push(RoutePaths.gameSettingsWithId(widget.sessionId)),
           behavior: HitTestBehavior.opaque,
-          child: SvgPicture.asset(
-            'assets/icons/icon_settiing_2.svg',
-            width: 24.w,
-            height: 24.w,
-            colorFilter: ColorFilter.mode(
-              isDark ? AppColors.black200 : AppColors.black800,
-              BlendMode.srcIn,
+          child: SizedBox(
+            width: 48.w,
+            height: 48.w,
+            child: Center(
+              child: SvgPicture.asset(
+                'assets/icons/icon_settiing_2.svg',
+                width: 24.w,
+                height: 24.w,
+                colorFilter: ColorFilter.mode(
+                  isDark ? AppColors.black200 : AppColors.black800,
+                  BlendMode.srcIn,
+                ),
+              ),
             ),
           ),
         ),
-        SizedBox(width: 24.w),
+        SizedBox(width: 12.w),
       ],
     );
   }


### PR DESCRIPTION
- 홈 화면 설정 아이콘 터치 영역 확대
- 대기실 앱바 info/설정 아이콘 터치 영역 확대
- 게임 화면 앱바 info 아이콘 터치 영역 확대

## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->


## ✅ 테스트
---

- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 게임 페이지, 홈 페이지, 대기실 페이지의 정보 및 설정 버튼의 터치 영역을 확대하여 클릭 용이성을 개선했습니다.
  * 대기실 페이지의 AppBar 아이콘 간 간격을 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->