### PR TITLE
20260412 #243 방 참여/생성 409 에러 시 기존 게임으로 자동 리다이렉트

### DIFF
--- a/lib/features/session/presentation/pages/home_page.dart
+++ b/lib/features/session/presentation/pages/home_page.dart
@@ -229,6 +229,15 @@ class _HomePageState extends ConsumerState<HomePage> {
           '${RoutePaths.gameWithId(info.gameId.toString())}'
           '?team=${info.team}&pid=${info.participantId}',
         );
+      } else {
+        debugPrint(
+          '⚠️ 알 수 없는 게임 상태: ${info.gameStatus} (gameId=${info.gameId})',
+        );
+        AppSnackbar.show(
+          context,
+          message: '알 수 없는 게임 상태입니다.',
+          backgroundColor: AppColors.red,
+        );
       }
     } catch (_) {
       // 활성 게임 조회도 실패 → fallback 스낵바

--- a/lib/features/session/presentation/pages/home_page.dart
+++ b/lib/features/session/presentation/pages/home_page.dart
@@ -201,6 +201,47 @@ class _HomePageState extends ConsumerState<HomePage> {
     }
   }
 
+  /// 409 "이미 참가 중인 게임" 에러 시 해당 게임으로 자동 이동
+  ///
+  /// `/api/user/me/game` 조회 → 게임 상태에 따라 대기실/게임 화면 이동.
+  /// 조회 실패 시 fallback 스낵바를 표시합니다.
+  Future<void> _redirectToActiveGame() async {
+    try {
+      final status = await ref.read(getMyActiveGameUsecaseProvider).execute();
+      if (!mounted) return;
+
+      if (!status.isParticipating || status.participationInfo == null) {
+        // 서버 상태 불일치 — 참가 중인 게임이 없음
+        AppSnackbar.show(
+          context,
+          message: '이미 참가 중인 게임이 있습니다.',
+          backgroundColor: AppColors.red,
+        );
+        return;
+      }
+
+      final info = status.participationInfo!;
+
+      if (info.gameStatus == 'WAITING') {
+        context.go(RoutePaths.waitingRoomWithId(info.gameId.toString()));
+      } else if (info.gameStatus == 'IN_PROGRESS') {
+        context.go(
+          '${RoutePaths.gameWithId(info.gameId.toString())}'
+          '?team=${info.team}&pid=${info.participantId}',
+        );
+      }
+    } catch (_) {
+      // 활성 게임 조회도 실패 → fallback 스낵바
+      if (mounted) {
+        AppSnackbar.show(
+          context,
+          message: '이미 참가 중인 게임이 있습니다.',
+          backgroundColor: AppColors.red,
+        );
+      }
+    }
+  }
+
   /// 위치 권한 확인 후 [onGranted] 실행
   ///
   /// 권한이 이미 허용된 경우 즉시 콜백 실행.
@@ -309,6 +350,11 @@ class _HomePageState extends ConsumerState<HomePage> {
     try {
       response = await ref.read(joinGameProvider(inviteCode: code).future);
     } on DioException catch (e) {
+      // 409: 이미 참가 중인 게임 → 해당 게임으로 자동 이동 시도
+      if (e.response?.statusCode == 409 && mounted) {
+        await _redirectToActiveGame();
+        return;
+      }
       if (mounted) {
         final apiError = ApiErrorResponse.tryParse(e.response?.data);
         final message = apiError?.detail ?? '참여에 실패했습니다. 초대 코드를 확인해주세요.';

--- a/lib/features/session/presentation/pages/session_creation_flow_page.dart
+++ b/lib/features/session/presentation/pages/session_creation_flow_page.dart
@@ -408,6 +408,16 @@ class _SessionCreationFlowPageState
           '${RoutePaths.gameWithId(info.gameId.toString())}'
           '?team=${info.team}&pid=${info.participantId}',
         );
+      } else {
+        debugPrint(
+          '⚠️ 알 수 없는 게임 상태: ${info.gameStatus} (gameId=${info.gameId})',
+        );
+        AppSnackbar.show(
+          context,
+          message: '알 수 없는 게임 상태입니다.',
+          backgroundColor: AppColors.red,
+        );
+        setState(() => _isLoading = false);
       }
     } catch (_) {
       if (mounted) {

--- a/lib/features/session/presentation/pages/session_creation_flow_page.dart
+++ b/lib/features/session/presentation/pages/session_creation_flow_page.dart
@@ -1,3 +1,4 @@
+import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -335,6 +336,12 @@ class _SessionCreationFlowPageState
         debugPrint('❌ [SessionCreationFlow] 세션 생성 실패: ${sessionState.error}');
       }
 
+      // 409: 이미 참가 중인 게임 → 해당 게임으로 자동 이동 시도
+      if (_is409Conflict(sessionState.error) && mounted) {
+        await _redirectToActiveGame();
+        return;
+      }
+
       if (mounted) {
         final errorMessage = _getErrorMessage(sessionState.error!);
         AppSnackbar.show(
@@ -359,6 +366,59 @@ class _SessionCreationFlowPageState
       return error.message;
     }
     return '게임 방 생성에 실패했습니다. 다시 시도해주세요.';
+  }
+
+  /// 에러가 409 Conflict인지 확인
+  ///
+  /// DioExceptionHandler가 변환한 AppException의 originalException에서
+  /// HTTP 상태 코드를 추출합니다.
+  bool _is409Conflict(Object? error) {
+    if (error is AppException && error.originalException is DioException) {
+      final dioError = error.originalException as DioException;
+      return dioError.response?.statusCode == 409;
+    }
+    return false;
+  }
+
+  /// 409 에러 시 활성 게임으로 자동 이동
+  ///
+  /// `/api/user/me/game` 조회 → 게임 상태에 따라 대기실/게임 화면 이동.
+  /// 조회 실패 시 fallback 스낵바를 표시하고 로딩 상태를 복원합니다.
+  Future<void> _redirectToActiveGame() async {
+    try {
+      final status = await ref.read(getMyActiveGameUsecaseProvider).execute();
+      if (!mounted) return;
+
+      if (!status.isParticipating || status.participationInfo == null) {
+        AppSnackbar.show(
+          context,
+          message: '이미 참가 중인 게임이 있습니다.',
+          backgroundColor: AppColors.red,
+        );
+        setState(() => _isLoading = false);
+        return;
+      }
+
+      final info = status.participationInfo!;
+
+      if (info.gameStatus == 'WAITING') {
+        context.go(RoutePaths.waitingRoomWithId(info.gameId.toString()));
+      } else if (info.gameStatus == 'IN_PROGRESS') {
+        context.go(
+          '${RoutePaths.gameWithId(info.gameId.toString())}'
+          '?team=${info.team}&pid=${info.participantId}',
+        );
+      }
+    } catch (_) {
+      if (mounted) {
+        AppSnackbar.show(
+          context,
+          message: '이미 참가 중인 게임이 있습니다.',
+          backgroundColor: AppColors.red,
+        );
+        setState(() => _isLoading = false);
+      }
+    }
   }
 
   // ============================================


### PR DESCRIPTION
## ✨ 변경 사항
- 방 참여(`POST /api/games/join`) 시 409 에러 발생하면 활성 게임 조회 후 대기실/게임 화면으로 자동 이동                              
- 방 생성(`POST /api/games`) 시 409 에러 발생하면 동일하게 자동 이동 처리                                                            
- 활성 게임 조회(`GET /api/user/me/game`) 실패 시 fallback 스낵바 표시

## ✅ 테스트

- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 게임 참여 중에 다른 게임 참가를 시도할 때, 자동으로 현재 게임 화면으로 리다이렉트되도록 개선했습니다. 기존의 일반적인 오류 메시지 대신 진행 중인 게임 상태(대기실 또는 게임 화면)로 직접 이동합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->