### PR TITLE
20260411 #241 재연결 후 도둑 발자국 복구 기능 추가

### DIFF
--- a/lib/core/constants/api_endpoints.dart
+++ b/lib/core/constants/api_endpoints.dart
@@ -127,6 +127,10 @@ class ApiEndpoints {
   /// 맵 영역 조회 (플레이그라운드·감옥 중심 좌표 및 반경)
   static String gameArea(int gameId) => '/api/games/$gameId/area';
 
+  /// 가장 최근 공개된 도둑 위치 목록 조회 (재연결 후 발자국 복구용)
+  static String robberLastLocations(int gameId) =>
+      '/api/games/$gameId/robbers/location';
+
   // ============================================
   // User API - 사용자 정보
   // ============================================

--- a/lib/core/constants/api_endpoints.dart
+++ b/lib/core/constants/api_endpoints.dart
@@ -45,8 +45,8 @@ class ApiEndpoints {
   /// Mock API 사용 여부 (.env에서 로드)
   /// Whether to use Mock API (loaded from .env)
   ///
-  /// **기본값**: `true`
-  /// **Default**: `true`
+  /// **기본값**: `false`
+  /// **Default**: `false`
   static bool get useMockApi =>
       dotenv.env['USE_MOCK_API']?.toLowerCase() == 'true';
 

--- a/lib/features/game/data/datasources/game_system_api_datasource.dart
+++ b/lib/features/game/data/datasources/game_system_api_datasource.dart
@@ -4,6 +4,7 @@ import 'package:retrofit/retrofit.dart';
 import '../../data/models/arrest_request_model.dart';
 import '../../data/models/arrest_response_model.dart';
 import '../../data/models/game_area_model.dart';
+export '../../data/models/game_area_model.dart' show RobberLocationModel;
 
 part 'game_system_api_datasource.g.dart';
 
@@ -30,4 +31,13 @@ abstract class GameSystemApi {
   /// 맵 영역 조회
   @GET('/api/games/{gameId}/area')
   Future<GameAreaModel> getArea(@Path('gameId') int gameId);
+
+  /// 가장 최근 공개된 도둑 위치 목록 조회
+  ///
+  /// 재연결 후 누락된 LOCATION_REVEAL 이벤트를 보완하기 위해 호출.
+  /// 아직 위치 공개 전이면 빈 배열 반환.
+  @GET('/api/games/{gameId}/robbers/location')
+  Future<List<RobberLocationModel>> getRobberLastLocations(
+    @Path('gameId') int gameId,
+  );
 }

--- a/lib/features/game/data/datasources/game_system_api_datasource.g.dart
+++ b/lib/features/game/data/datasources/game_system_api_datasource.g.dart
@@ -93,6 +93,38 @@ class _GameSystemApi implements GameSystemApi {
     return _value;
   }
 
+  @override
+  Future<List<RobberLocationModel>> getRobberLastLocations(int gameId) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<List<RobberLocationModel>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/api/games/${gameId}/robbers/location',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<List<dynamic>>(_options);
+    late List<RobberLocationModel> _value;
+    try {
+      _value = _result.data!
+          .map(
+            (dynamic i) =>
+                RobberLocationModel.fromJson(i as Map<String, dynamic>),
+          )
+          .toList();
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
     if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||

--- a/lib/features/game/data/models/game_area_model.dart
+++ b/lib/features/game/data/models/game_area_model.dart
@@ -15,6 +15,23 @@ class LatLngModel with _$LatLngModel {
       _$LatLngModelFromJson(json);
 }
 
+/// 도둑 마지막 공개 위치 DTO
+///
+/// `GET /api/games/{gameId}/robbers/location` 응답 항목.
+/// 재연결 후 누락된 LOCATION_REVEAL 이벤트 복구에 사용합니다.
+@freezed
+class RobberLocationModel with _$RobberLocationModel {
+  const factory RobberLocationModel({
+    required int participantId,
+    required String nickname,
+    required double latitude,
+    required double longitude,
+  }) = _RobberLocationModel;
+
+  factory RobberLocationModel.fromJson(Map<String, dynamic> json) =>
+      _$RobberLocationModelFromJson(json);
+}
+
 /// 게임 맵 영역 DTO
 ///
 /// `GET /api/games/{gameId}/area` 응답.

--- a/lib/features/game/data/models/game_area_model.freezed.dart
+++ b/lib/features/game/data/models/game_area_model.freezed.dart
@@ -185,6 +185,237 @@ abstract class _LatLngModel implements LatLngModel {
       throw _privateConstructorUsedError;
 }
 
+RobberLocationModel _$RobberLocationModelFromJson(Map<String, dynamic> json) {
+  return _RobberLocationModel.fromJson(json);
+}
+
+/// @nodoc
+mixin _$RobberLocationModel {
+  int get participantId => throw _privateConstructorUsedError;
+  String get nickname => throw _privateConstructorUsedError;
+  double get latitude => throw _privateConstructorUsedError;
+  double get longitude => throw _privateConstructorUsedError;
+
+  /// Serializes this RobberLocationModel to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of RobberLocationModel
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $RobberLocationModelCopyWith<RobberLocationModel> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $RobberLocationModelCopyWith<$Res> {
+  factory $RobberLocationModelCopyWith(
+    RobberLocationModel value,
+    $Res Function(RobberLocationModel) then,
+  ) = _$RobberLocationModelCopyWithImpl<$Res, RobberLocationModel>;
+  @useResult
+  $Res call({
+    int participantId,
+    String nickname,
+    double latitude,
+    double longitude,
+  });
+}
+
+/// @nodoc
+class _$RobberLocationModelCopyWithImpl<$Res, $Val extends RobberLocationModel>
+    implements $RobberLocationModelCopyWith<$Res> {
+  _$RobberLocationModelCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of RobberLocationModel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? participantId = null,
+    Object? nickname = null,
+    Object? latitude = null,
+    Object? longitude = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            participantId: null == participantId
+                ? _value.participantId
+                : participantId // ignore: cast_nullable_to_non_nullable
+                      as int,
+            nickname: null == nickname
+                ? _value.nickname
+                : nickname // ignore: cast_nullable_to_non_nullable
+                      as String,
+            latitude: null == latitude
+                ? _value.latitude
+                : latitude // ignore: cast_nullable_to_non_nullable
+                      as double,
+            longitude: null == longitude
+                ? _value.longitude
+                : longitude // ignore: cast_nullable_to_non_nullable
+                      as double,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$RobberLocationModelImplCopyWith<$Res>
+    implements $RobberLocationModelCopyWith<$Res> {
+  factory _$$RobberLocationModelImplCopyWith(
+    _$RobberLocationModelImpl value,
+    $Res Function(_$RobberLocationModelImpl) then,
+  ) = __$$RobberLocationModelImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    int participantId,
+    String nickname,
+    double latitude,
+    double longitude,
+  });
+}
+
+/// @nodoc
+class __$$RobberLocationModelImplCopyWithImpl<$Res>
+    extends _$RobberLocationModelCopyWithImpl<$Res, _$RobberLocationModelImpl>
+    implements _$$RobberLocationModelImplCopyWith<$Res> {
+  __$$RobberLocationModelImplCopyWithImpl(
+    _$RobberLocationModelImpl _value,
+    $Res Function(_$RobberLocationModelImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of RobberLocationModel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? participantId = null,
+    Object? nickname = null,
+    Object? latitude = null,
+    Object? longitude = null,
+  }) {
+    return _then(
+      _$RobberLocationModelImpl(
+        participantId: null == participantId
+            ? _value.participantId
+            : participantId // ignore: cast_nullable_to_non_nullable
+                  as int,
+        nickname: null == nickname
+            ? _value.nickname
+            : nickname // ignore: cast_nullable_to_non_nullable
+                  as String,
+        latitude: null == latitude
+            ? _value.latitude
+            : latitude // ignore: cast_nullable_to_non_nullable
+                  as double,
+        longitude: null == longitude
+            ? _value.longitude
+            : longitude // ignore: cast_nullable_to_non_nullable
+                  as double,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$RobberLocationModelImpl implements _RobberLocationModel {
+  const _$RobberLocationModelImpl({
+    required this.participantId,
+    required this.nickname,
+    required this.latitude,
+    required this.longitude,
+  });
+
+  factory _$RobberLocationModelImpl.fromJson(Map<String, dynamic> json) =>
+      _$$RobberLocationModelImplFromJson(json);
+
+  @override
+  final int participantId;
+  @override
+  final String nickname;
+  @override
+  final double latitude;
+  @override
+  final double longitude;
+
+  @override
+  String toString() {
+    return 'RobberLocationModel(participantId: $participantId, nickname: $nickname, latitude: $latitude, longitude: $longitude)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$RobberLocationModelImpl &&
+            (identical(other.participantId, participantId) ||
+                other.participantId == participantId) &&
+            (identical(other.nickname, nickname) ||
+                other.nickname == nickname) &&
+            (identical(other.latitude, latitude) ||
+                other.latitude == latitude) &&
+            (identical(other.longitude, longitude) ||
+                other.longitude == longitude));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, participantId, nickname, latitude, longitude);
+
+  /// Create a copy of RobberLocationModel
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$RobberLocationModelImplCopyWith<_$RobberLocationModelImpl> get copyWith =>
+      __$$RobberLocationModelImplCopyWithImpl<_$RobberLocationModelImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$RobberLocationModelImplToJson(this);
+  }
+}
+
+abstract class _RobberLocationModel implements RobberLocationModel {
+  const factory _RobberLocationModel({
+    required final int participantId,
+    required final String nickname,
+    required final double latitude,
+    required final double longitude,
+  }) = _$RobberLocationModelImpl;
+
+  factory _RobberLocationModel.fromJson(Map<String, dynamic> json) =
+      _$RobberLocationModelImpl.fromJson;
+
+  @override
+  int get participantId;
+  @override
+  String get nickname;
+  @override
+  double get latitude;
+  @override
+  double get longitude;
+
+  /// Create a copy of RobberLocationModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$RobberLocationModelImplCopyWith<_$RobberLocationModelImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
 GameAreaModel _$GameAreaModelFromJson(Map<String, dynamic> json) {
   return _GameAreaModel.fromJson(json);
 }

--- a/lib/features/game/data/models/game_area_model.g.dart
+++ b/lib/features/game/data/models/game_area_model.g.dart
@@ -18,6 +18,24 @@ Map<String, dynamic> _$$LatLngModelImplToJson(_$LatLngModelImpl instance) =>
       'longitude': instance.longitude,
     };
 
+_$RobberLocationModelImpl _$$RobberLocationModelImplFromJson(
+  Map<String, dynamic> json,
+) => _$RobberLocationModelImpl(
+  participantId: (json['participantId'] as num).toInt(),
+  nickname: json['nickname'] as String,
+  latitude: (json['latitude'] as num).toDouble(),
+  longitude: (json['longitude'] as num).toDouble(),
+);
+
+Map<String, dynamic> _$$RobberLocationModelImplToJson(
+  _$RobberLocationModelImpl instance,
+) => <String, dynamic>{
+  'participantId': instance.participantId,
+  'nickname': instance.nickname,
+  'latitude': instance.latitude,
+  'longitude': instance.longitude,
+};
+
 _$GameAreaModelImpl _$$GameAreaModelImplFromJson(Map<String, dynamic> json) =>
     _$GameAreaModelImpl(
       playgroundCenter: LatLngModel.fromJson(

--- a/lib/features/game/presentation/providers/game_event_provider.dart
+++ b/lib/features/game/presentation/providers/game_event_provider.dart
@@ -657,6 +657,8 @@ class GameEventNotifier extends _$GameEventNotifier {
         _reconnectTimer?.cancel();
         _reconnectTimer = null;
         state = state.copyWith(errorMessage: null);
+        // 재연결 후 누락된 도둑 발자국 복구
+        if (_gameId != null) _fetchLastRobberLocations(_gameId!);
       } else if (connState == StompConnectionState.disconnected) {
         if (!_intentionalDisconnect && !_isHandlingError) {
           _scheduleReconnect();
@@ -670,6 +672,32 @@ class GameEventNotifier extends _$GameEventNotifier {
       _isHandlingError = true;
       _handleStompError(errorInfo);
     });
+  }
+
+  /// 재연결 후 마지막으로 공개된 도둑 위치를 조회하여 발자국 복구
+  ///
+  /// STOMP 연결 유실 중 LOCATION_REVEAL 이벤트를 놓쳤을 때 호출.
+  /// 빈 배열(아직 공개 전)이면 상태 변경 없이 무시.
+  Future<void> _fetchLastRobberLocations(int gameId) async {
+    try {
+      final locations = await ref
+          .read(gameSystemApiProvider)
+          .getRobberLastLocations(gameId);
+      if (locations.isEmpty) return;
+
+      final entries = {
+        for (final loc in locations)
+          loc.participantId: LatLngModel(
+            latitude: loc.latitude,
+            longitude: loc.longitude,
+          ),
+      };
+      state = state.copyWith(robberLocations: entries);
+      debugPrint('[GameEventNotifier] 📍 재연결 후 도둑 위치 복구: ${entries.length}명');
+    } catch (e) {
+      // 위치 복구 실패는 치명적이지 않으므로 조용히 처리
+      debugPrint('[GameEventNotifier] ⚠️ 마지막 위치 조회 실패: $e');
+    }
   }
 
   void _scheduleReconnect() {

--- a/lib/features/game/presentation/providers/game_event_provider.dart
+++ b/lib/features/game/presentation/providers/game_event_provider.dart
@@ -678,12 +678,26 @@ class GameEventNotifier extends _$GameEventNotifier {
   ///
   /// STOMP 연결 유실 중 LOCATION_REVEAL 이벤트를 놓쳤을 때 호출.
   /// 빈 배열(아직 공개 전)이면 상태 변경 없이 무시.
+  /// await 중 dispose되거나 새 LOCATION_REVEAL이 도착한 경우 덮어쓰지 않음.
   Future<void> _fetchLastRobberLocations(int gameId) async {
+    // fetch 시작 시점의 reveal 타임스탬프 캡처 (race condition 방지)
+    final preRevealTime = state.lastLocationRevealTime;
     try {
       final locations = await ref
           .read(gameSystemApiProvider)
           .getRobberLastLocations(gameId);
+
+      // dispose 후 state 접근 방지
+      if (_isDisposed) return;
       if (locations.isEmpty) return;
+
+      // await 중 새 LOCATION_REVEAL 이벤트가 도착했으면 fetch 결과를 무시
+      if (state.lastLocationRevealTime != preRevealTime) {
+        debugPrint(
+          '[GameEventNotifier] ⏭️ 도둑 위치 복구 생략 (새 LOCATION_REVEAL 수신됨)',
+        );
+        return;
+      }
 
       final entries = {
         for (final loc in locations)

--- a/lib/features/game/presentation/providers/game_event_provider.g.dart
+++ b/lib/features/game/presentation/providers/game_event_provider.g.dart
@@ -47,7 +47,7 @@ final gameSystemApiProvider = AutoDisposeProvider<GameSystemApi>.internal(
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
 typedef GameSystemApiRef = AutoDisposeProviderRef<GameSystemApi>;
-String _$gameEventNotifierHash() => r'b75580d0bb97d2c9407f22ed8dc90e29674dce68';
+String _$gameEventNotifierHash() => r'ebb71667b170a08d108edb5650d7349c52e9e471';
 
 /// 게임 이벤트 상태 관리 Notifier
 ///


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->
- 도둑 마지막 위치 조회 API 모델 및 엔드포인트 추가 (GET /api/games/{gameId}/robbers/last-locations)                               
- 도둑 마지막 위치 조회 메서드 추가                                                                      
- 재연결 후 도둑 발자국(footprint) 복구 로직 추가

## ✅ 테스트

- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 게임 내 강도들의 마지막 위치 정보를 확인할 수 있는 기능이 추가되었습니다. 각 강도의 위치는 닉네임, 위도 및 경도 정보로 제공됩니다.
  * 게임 서버 연결이 재개될 때 강도의 위치 정보가 자동으로 업데이트되어 항상 최신 상태를 유지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->