### PR TITLE
20260411 #242 web socket 재연결 시 게임 상태 동기화 누락 수정

### DIFF
--- a/lib/features/game/presentation/pages/game_page.dart
+++ b/lib/features/game/presentation/pages/game_page.dart
@@ -533,6 +533,42 @@ class _GamePageState extends ConsumerState<GamePage>
     ref.read(gameAreaProvider(_gameId));
   }
 
+  /// WebSocket 재연결 성공 후 게임 상태 동기화
+  ///
+  /// STOMP는 끊김 구간의 이벤트를 재전송하지 않으므로,
+  /// 재연결 시 서버 참가자 목록을 직접 조회해 체포 현황과 남은 도둑 수를 보정합니다.
+  Future<void> _syncGameStateOnReconnect() async {
+    if (widget.isDummy || !mounted) return;
+
+    try {
+      // autoDispose provider이므로 ref.refresh로 최신 데이터 보장
+      final result = await ref.refresh(
+        fetchGameParticipantsProvider(_gameId).future,
+      );
+
+      if (!mounted) return;
+
+      // 서버 응답에서 수감 중인 도둑 ID 집합과 생존 도둑 수 추출
+      final arrestedIds = result.robbers
+          .where((p) => p.status == 'JAILED')
+          .map((p) => p.participantId)
+          .toSet();
+      final remainingThieves = result.robbers
+          .where((p) => p.status == 'ALIVE')
+          .length;
+
+      ref
+          .read(gameEventNotifierProvider.notifier)
+          .syncFromParticipants(
+            arrestedIds: arrestedIds,
+            remainingThieves: remainingThieves,
+          );
+    } catch (e) {
+      // 동기화 실패 시 게임 진행에 지장을 주지 않도록 예외를 삼킴
+      debugPrint('[GamePage] ⚠️ 재연결 후 상태 동기화 실패 (무시): $e');
+    }
+  }
+
   /// 도둑 팀 GPS 위치 스트림 구독 및 서버 전송 시작
   ///
   /// distanceFilter 10m로 OS 레벨에서 필터링하고,
@@ -1187,15 +1223,20 @@ class _GamePageState extends ConsumerState<GamePage>
       prev,
       next,
     ) {
-      // 재연결 성공 → 도둑 팀 위치 즉시 재전송
+      // 재연결 성공 → 게임 상태 동기화 + 도둑 팀 위치 즉시 재전송
       if (next == StompConnectionState.connected &&
-          prev != StompConnectionState.connected &&
-          widget.team == 'ROBBER' &&
-          !widget.isDummy) {
-        if (_lastSentPosition != null) {
-          _sendPositionNow();
-        } else if (_locationSubscription == null) {
-          _startLocationSending();
+          prev != StompConnectionState.connected) {
+        // 끊김 구간 동안 누락된 체포·탈옥 이벤트를 서버 조회로 보정
+        if (_hasGameEventConnectedOnce) {
+          _syncGameStateOnReconnect();
+        }
+
+        if (widget.team == 'ROBBER' && !widget.isDummy) {
+          if (_lastSentPosition != null) {
+            _sendPositionNow();
+          } else if (_locationSubscription == null) {
+            _startLocationSending();
+          }
         }
       }
 

--- a/lib/features/game/presentation/pages/game_page.dart
+++ b/lib/features/game/presentation/pages/game_page.dart
@@ -541,6 +541,11 @@ class _GamePageState extends ConsumerState<GamePage>
     if (widget.isDummy || !mounted) return;
 
     try {
+      // sync 요청 직전 상태 snapshot — sync 창에 STOMP가 추가한 변화 추적용
+      final before = ref.read(gameEventNotifierProvider);
+      final arrestedBefore = before.arrestedParticipantIds;
+      final escapedBefore = before.escapedParticipantIds;
+
       // autoDispose provider이므로 ref.refresh로 최신 데이터 보장
       final result = await ref.refresh(
         fetchGameParticipantsProvider(_gameId).future,
@@ -548,19 +553,44 @@ class _GamePageState extends ConsumerState<GamePage>
 
       if (!mounted) return;
 
-      // 서버 응답에서 수감 중인 도둑 ID 집합과 생존 도둑 수 추출
-      final arrestedIds = result.robbers
+      // sync 요청~응답 사이에 STOMP가 반영한 ID delta 계산
+      // HTTP 응답(서버 snapshot)은 요청 시점 기준이라, 그 동안 STOMP로 들어온
+      // 신규 체포/탈옥을 덮어쓰지 않도록 delta를 별도로 추출해 layer한다.
+      final after = ref.read(gameEventNotifierProvider);
+      final stompNewArrests = after.arrestedParticipantIds.difference(
+        arrestedBefore,
+      );
+      final stompNewEscapes = after.escapedParticipantIds.difference(
+        escapedBefore,
+      );
+
+      // 서버 snapshot 기반 수감자 집합
+      final serverArrested = result.robbers
           .where((p) => p.status == 'JAILED')
           .map((p) => p.participantId)
           .toSet();
-      final remainingThieves = result.robbers
+
+      // 서버 snapshot 위에 sync 창 delta layer:
+      //   - STOMP가 새로 체포한 사람은 추가
+      //   - STOMP가 새로 탈옥시킨 사람은 제외
+      final finalArrested = serverArrested
+          .union(stompNewArrests)
+          .difference(stompNewEscapes);
+
+      // 서버 기준 생존 수에 sync 창 delta를 반영 (음수 clamp)
+      final serverAlive = result.robbers
           .where((p) => p.status == 'ALIVE')
           .length;
+      final remainingThieves =
+          (serverAlive - stompNewArrests.length + stompNewEscapes.length).clamp(
+            0,
+            1 << 31,
+          );
 
       ref
           .read(gameEventNotifierProvider.notifier)
           .syncFromParticipants(
-            arrestedIds: arrestedIds,
+            arrestedIds: finalArrested,
             remainingThieves: remainingThieves,
           );
     } catch (e) {

--- a/lib/features/game/presentation/pages/game_page.dart
+++ b/lib/features/game/presentation/pages/game_page.dart
@@ -577,14 +577,14 @@ class _GamePageState extends ConsumerState<GamePage>
           .union(stompNewArrests)
           .difference(stompNewEscapes);
 
-      // 서버 기준 생존 수에 sync 창 delta를 반영 (음수 clamp)
+      // 서버 기준 생존 수에 sync 창 delta를 반영 (0 ~ 전체 도둑 수 범위로 clamp)
       final serverAlive = result.robbers
           .where((p) => p.status == 'ALIVE')
           .length;
       final remainingThieves =
           (serverAlive - stompNewArrests.length + stompNewEscapes.length).clamp(
             0,
-            1 << 31,
+            result.robbers.length,
           );
 
       ref
@@ -1256,9 +1256,11 @@ class _GamePageState extends ConsumerState<GamePage>
       // 재연결 성공 → 게임 상태 동기화 + 도둑 팀 위치 즉시 재전송
       if (next == StompConnectionState.connected &&
           prev != StompConnectionState.connected) {
-        // 끊김 구간 동안 누락된 체포·탈옥 이벤트를 서버 조회로 보정
+        // 끊김 구간 동안 누락된 체포·탈옥 이벤트를 서버 조회로 보정.
+        // 의도적으로 await하지 않음 — 아래 도둑 팀 위치 즉시 재전송이
+        // HTTP 응답을 기다리다 지연되지 않도록. 에러는 메서드 내부 try-catch에서 처리.
         if (_hasGameEventConnectedOnce) {
-          _syncGameStateOnReconnect();
+          unawaited(_syncGameStateOnReconnect());
         }
 
         if (widget.team == 'ROBBER' && !widget.isDummy) {

--- a/lib/features/game/presentation/providers/game_event_provider.dart
+++ b/lib/features/game/presentation/providers/game_event_provider.dart
@@ -455,6 +455,34 @@ class GameEventNotifier extends _$GameEventNotifier {
     });
   }
 
+  /// WebSocket 재연결 후 서버 참가자 상태로 게임 상태를 동기화
+  ///
+  /// STOMP는 끊김 구간의 이벤트를 재전송하지 않으므로, 재연결 시
+  /// GET /api/games/{gameId}/participants 응답으로 누락된 체포·탈옥 상태를 보정합니다.
+  ///
+  /// [arrestedIds] - 서버 응답 기준 현재 수감 중인 도둑 participantId 집합
+  /// [remainingThieves] - 서버 응답 기준 현재 생존(ALIVE) 도둑 수
+  void syncFromParticipants({
+    required Set<int> arrestedIds,
+    required int remainingThieves,
+  }) {
+    if (_isDisposed) return;
+
+    debugPrint(
+      '[GameEventNotifier] 🔄 재연결 후 상태 동기화 — '
+      '수감: $arrestedIds, 남은 도둑: $remainingThieves',
+    );
+
+    // 기존 상태와 병합: 서버 기준 수감자를 우선 적용하되,
+    // 이미 escape 처리된 참가자는 수감 집합에서 제외
+    final mergedArrested = arrestedIds.difference(state.escapedParticipantIds);
+
+    state = state.copyWith(
+      arrestedParticipantIds: mergedArrested,
+      remainingThieves: remainingThieves,
+    );
+  }
+
   /// 외부에서 배너 메시지를 설정 (게임 시작 시퀀스 등 STOMP 외 이벤트용)
   void setBannerMessage(String message) {
     state = state.copyWith(bannerMessage: message);

--- a/lib/features/game/presentation/providers/game_event_provider.dart
+++ b/lib/features/game/presentation/providers/game_event_provider.dart
@@ -473,12 +473,13 @@ class GameEventNotifier extends _$GameEventNotifier {
       '수감: $arrestedIds, 남은 도둑: $remainingThieves',
     );
 
-    // 기존 상태와 병합: 서버 기준 수감자를 우선 적용하되,
-    // 이미 escape 처리된 참가자는 수감 집합에서 제외
-    final mergedArrested = arrestedIds.difference(state.escapedParticipantIds);
-
+    // 서버가 진실의 원천. 끊김 구간에 탈옥→재체포가 발생해도
+    // 서버의 JAILED 목록을 그대로 반영하고, escaped 집합은 현재 수감자와 겹치지 않게 정리한다.
     state = state.copyWith(
-      arrestedParticipantIds: mergedArrested,
+      arrestedParticipantIds: arrestedIds,
+      escapedParticipantIds: state.escapedParticipantIds.difference(
+        arrestedIds,
+      ),
       remainingThieves: remainingThieves,
     );
   }


### PR DESCRIPTION
## ✨ 변경 사항
- WebSocket 재연결 시 참가자 API로 체포·탈옥 상태 동기화             
                                                                          
  - 끊김 구간에 탈옥→재체포된 본인이 잠금 오버레이 누락되던 버그 수정                                                                               
  - sync 응답이 그 사이 수신된 STOMP 이벤트를 덮어쓰지 않도록 보정

## ✅ 테스트

- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 네트워크 재연결 시 클라이언트 게임 상태를 서버 참가자 정보로 정확히 재동기화하도록 개선되었습니다.
  * 재연결 후 체포·도주 상태 및 남은 도둑 수가 서버 기준으로 정합성 있게 갱신되며, 이후 위치 재전송 로직이 정상적으로 재개됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->