### PR TITLE
20260422 #276 도둑 체포 qr에 만료시각 ttl 추가하여 재사용 방지

### DIFF
--- a/lib/core/constants/game_config.dart
+++ b/lib/core/constants/game_config.dart
@@ -80,4 +80,15 @@ class GameConfig {
   /// 감옥 이탈 시 위치 노출 시간 (10초)
   /// Location exposure time after jail exit (10 seconds)
   static const Duration jailExitExposureTime = Duration(seconds: 10);
+
+  // ============================================
+  // QR 체포 설정 (QR Arrest Settings)
+  // ============================================
+
+  /// 도둑 QR 페이로드 유효 기간 (30초)
+  ///
+  /// 이 시간이 지난 QR은 경찰 스캔 시 거부된다. 스크린샷 저장 후 재사용하는
+  /// 리플레이 공격을 차단하기 위한 값이며, 정상 대면 체포 플로우(수 초 이내)는
+  /// 충분히 여유 있게 커버한다.
+  static const Duration qrPayloadTtl = Duration(seconds: 30);
 }

--- a/lib/features/game/domain/qr_payload.dart
+++ b/lib/features/game/domain/qr_payload.dart
@@ -1,0 +1,72 @@
+import 'dart:convert';
+
+/// 도둑 체포용 QR 페이로드
+///
+/// 참가자 ID와 만료시각을 담는 값 객체. 도둑 측에서 QR을 만들 때 사용하고,
+/// 경찰 측에서 스캔된 문자열을 파싱·검증할 때 동일한 클래스를 공유한다.
+/// 이 모델을 통해 생성/파싱을 단일 지점에서 관리하여 포맷 불일치를 방지한다.
+///
+/// 인코딩 포맷: `{"pid": <int>, "exp": <Unix millisecond int>}`
+class QrPayload {
+  const QrPayload({
+    required this.participantId,
+    required this.expiresAt,
+  });
+
+  /// 도둑의 참가자 ID
+  final int participantId;
+
+  /// 이 페이로드의 만료시각 (이 시각 이후 스캔된 QR은 무효 처리)
+  final DateTime expiresAt;
+
+  /// 현재 시각 기준으로 [ttl]만큼 유효한 새 페이로드를 만든다.
+  ///
+  /// 도둑 다이얼로그가 열릴 때 호출되어 신선한 만료시각을 부여한다.
+  factory QrPayload.freshFor({
+    required int participantId,
+    required DateTime now,
+    required Duration ttl,
+  }) {
+    return QrPayload(
+      participantId: participantId,
+      expiresAt: now.add(ttl),
+    );
+  }
+
+  /// 스캔된 원본 문자열을 파싱한다. 형식 오류 시 `null` 반환.
+  ///
+  /// [QrScannerPage] 의 `onParse` 콜백에 그대로 대입할 수 있도록
+  /// `T? Function(String)` 시그니처에 맞춰 정의한다.
+  static QrPayload? tryParse(String raw) {
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map<String, dynamic>) return null;
+
+      // JSON 디코더는 정수를 int 또는 num으로 반환할 수 있어 양쪽 모두 허용.
+      final pid = decoded['pid'];
+      final exp = decoded['exp'];
+      if (pid is! num) return null;
+      if (exp is! num) return null;
+
+      return QrPayload(
+        participantId: pid.toInt(),
+        expiresAt: DateTime.fromMillisecondsSinceEpoch(exp.toInt()),
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// QR 이미지에 인코딩할 JSON 문자열을 생성한다.
+  String toRaw() {
+    return jsonEncode({
+      'pid': participantId,
+      'exp': expiresAt.millisecondsSinceEpoch,
+    });
+  }
+
+  /// [now] 시점 기준 만료 여부를 판정한다.
+  ///
+  /// `expiresAt`과 정확히 같은 시각도 만료로 취급 (경계 닫힘).
+  bool isExpiredAt(DateTime now) => !now.isBefore(expiresAt);
+}

--- a/lib/features/game/domain/qr_payload.dart
+++ b/lib/features/game/domain/qr_payload.dart
@@ -36,15 +36,16 @@ class QrPayload {
       final decoded = jsonDecode(raw);
       if (decoded is! Map<String, dynamic>) return null;
 
-      // JSON 디코더는 정수를 int 또는 num으로 반환할 수 있어 양쪽 모두 허용.
+      // pid/exp는 int 전용. fractional 값(예: 123.9)이 암묵적으로 절삭되는 것을
+      // 막기 위해 명시적으로 거부한다. 정상 QR은 jsonDecode가 항상 int로 파싱.
       final pid = decoded['pid'];
       final exp = decoded['exp'];
-      if (pid is! num) return null;
-      if (exp is! num) return null;
+      if (pid is! int) return null;
+      if (exp is! int) return null;
 
       return QrPayload(
-        participantId: pid.toInt(),
-        expiresAt: DateTime.fromMillisecondsSinceEpoch(exp.toInt()),
+        participantId: pid,
+        expiresAt: DateTime.fromMillisecondsSinceEpoch(exp),
       );
     } catch (_) {
       return null;

--- a/lib/features/game/domain/qr_payload.dart
+++ b/lib/features/game/domain/qr_payload.dart
@@ -8,10 +8,7 @@ import 'dart:convert';
 ///
 /// 인코딩 포맷: `{"pid": <int>, "exp": <Unix millisecond int>}`
 class QrPayload {
-  const QrPayload({
-    required this.participantId,
-    required this.expiresAt,
-  });
+  const QrPayload({required this.participantId, required this.expiresAt});
 
   /// 도둑의 참가자 ID
   final int participantId;
@@ -27,10 +24,7 @@ class QrPayload {
     required DateTime now,
     required Duration ttl,
   }) {
-    return QrPayload(
-      participantId: participantId,
-      expiresAt: now.add(ttl),
-    );
+    return QrPayload(participantId: participantId, expiresAt: now.add(ttl));
   }
 
   /// 스캔된 원본 문자열을 파싱한다. 형식 오류 시 `null` 반환.

--- a/lib/features/game/presentation/pages/game_page.dart
+++ b/lib/features/game/presentation/pages/game_page.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
@@ -38,6 +37,7 @@ import '../../../session/presentation/providers/session_provider.dart';
 import '../../../session/presentation/widgets/game_rules_content.dart';
 import '../../data/datasources/game_event_stomp_datasource.dart';
 import '../../data/models/game_area_model.dart';
+import '../../domain/qr_payload.dart';
 import '../../domain/zone_exit_detector.dart';
 import '../helpers/zone_exit_reconnect_policy.dart';
 import '../providers/game_area_provider.dart';
@@ -1596,26 +1596,28 @@ class _GamePageState extends ConsumerState<GamePage>
       return;
     }
 
-    final participantId = await Navigator.push<int>(
+    // 스캐너는 파싱만 담당. 만료 여부는 호출측에서 검증하여 사용자에게 원인을 명확히 안내한다.
+    final payload = await Navigator.push<QrPayload>(
       context,
       MaterialPageRoute(
-        builder: (_) => QrScannerPage<int>(
+        builder: (_) => QrScannerPage<QrPayload>(
           title: '도둑의 수배 QR을 스캔하세요',
-          onParse: (rawValue) {
-            try {
-              final json = jsonDecode(rawValue) as Map<String, dynamic>;
-              final pid = json['pid'];
-              if (pid is int) return pid;
-              if (pid is num) return pid.toInt();
-              return null;
-            } catch (_) {
-              return null;
-            }
-          },
+          onParse: QrPayload.tryParse,
         ),
       ),
     );
-    if (participantId == null || !mounted) return;
+    if (payload == null || !mounted) return;
+
+    // 만료된 QR (스크린샷 저장 후 재사용 시나리오 등) 차단
+    if (payload.isExpiredAt(DateTime.now())) {
+      AppSnackbar.show(
+        context,
+        message: '만료된 QR입니다. 도둑에게 QR 새로고침을 요청하세요.',
+      );
+      return;
+    }
+
+    final participantId = payload.participantId;
 
     // 이미 체포된 도둑 체크
     final arrestedIds = ref

--- a/lib/features/game/presentation/pages/game_page.dart
+++ b/lib/features/game/presentation/pages/game_page.dart
@@ -294,7 +294,7 @@ class _GamePageState extends ConsumerState<GamePage>
       AppTutorialStyle.target(
         keyTarget: _tutorialKeyQrButton,
         description: widget.team == 'POLICE'
-            ? '도둑 참가자 카드를 누르거나 QR을 스캔해서 체포해요'
+            ? '도둑의 QR을 스캔해서 체포해요'
             : '잡히면 경찰에게 QR을 보여주고, 경찰이 스캔하면 체포돼요',
       ),
     ];
@@ -1610,10 +1610,7 @@ class _GamePageState extends ConsumerState<GamePage>
 
     // 만료된 QR (스크린샷 저장 후 재사용 시나리오 등) 차단
     if (payload.isExpiredAt(DateTime.now())) {
-      AppSnackbar.show(
-        context,
-        message: '만료된 QR입니다. 도둑에게 QR 새로고침을 요청하세요.',
-      );
+      AppSnackbar.show(context, message: '만료된 QR입니다. QR 새로고침을 요청하세요');
       return;
     }
 

--- a/lib/features/game/presentation/widgets/qr_display_dialog.dart
+++ b/lib/features/game/presentation/widgets/qr_display_dialog.dart
@@ -1,20 +1,24 @@
-import 'dart:convert';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 
 import '../../../../core/constants/app_colors.dart';
+import '../../../../core/constants/game_config.dart';
 import '../../../../core/constants/spacing_and_radius.dart';
 import '../../../../core/constants/text_styles.dart';
 import '../../../../core/widgets/buttons/app_button.dart';
+import '../../domain/qr_payload.dart';
 
 /// 도둑 QR 코드 표시 다이얼로그
 ///
 /// 도둑의 `participantId`를 QR 코드로 인코딩하여 화면에 표시한다.
 /// 경찰이 이 QR을 스캔하여 체포를 수행한다.
 ///
-/// QR 데이터 형식: `{"pid": <participantId>}`
+/// 다이얼로그가 열리는 시점에 [GameConfig.qrPayloadTtl] 만큼 유효한
+/// 페이로드를 생성한다. 스캔되기 전에 시간이 지나면 만료되므로 스크린샷
+/// 저장 후 재사용하는 리플레이 공격을 차단한다.
+///
+/// QR 데이터 형식: `{"pid": <participantId>, "exp": <만료시각 ms>}`
 class QrDisplayDialog extends StatelessWidget {
   const QrDisplayDialog({required this.participantId, super.key});
 
@@ -35,7 +39,13 @@ class QrDisplayDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final qrData = jsonEncode({'pid': participantId});
+    // 다이얼로그가 열릴 때마다 TTL 30초짜리 신선한 페이로드 발급.
+    // 닫고 다시 열면 자동으로 새 만료시각이 부여되어 자연스럽게 복구된다.
+    final qrData = QrPayload.freshFor(
+      participantId: participantId,
+      now: DateTime.now(),
+      ttl: GameConfig.qrPayloadTtl,
+    ).toRaw();
 
     return Dialog(
       backgroundColor: AppColors.black,

--- a/test/features/game/domain/qr_payload_test.dart
+++ b/test/features/game/domain/qr_payload_test.dart
@@ -67,9 +67,7 @@ void main() {
 
     test('pid가 num(double) 타입이어도 int로 정규화하여 허용한다', () {
       // 실제 JSON 파싱에서 정수가 num으로 들어올 수 있음
-      final parsed = QrPayload.tryParse(
-        '{"pid": 102, "exp": 1729508430000}',
-      );
+      final parsed = QrPayload.tryParse('{"pid": 102, "exp": 1729508430000}');
       expect(parsed, isNotNull);
       expect(parsed!.participantId, 102);
     });
@@ -89,17 +87,11 @@ void main() {
     });
 
     test('expiresAt과 정확히 같은 시각은 만료로 판정한다', () {
-      expect(
-        payload.isExpiredAt(DateTime(2026, 4, 22, 12, 0, 30)),
-        isTrue,
-      );
+      expect(payload.isExpiredAt(DateTime(2026, 4, 22, 12, 0, 30)), isTrue);
     });
 
     test('expiresAt 1ms 이후는 만료로 판정한다', () {
-      expect(
-        payload.isExpiredAt(DateTime(2026, 4, 22, 12, 0, 30, 1)),
-        isTrue,
-      );
+      expect(payload.isExpiredAt(DateTime(2026, 4, 22, 12, 0, 30, 1)), isTrue);
     });
   });
 }

--- a/test/features/game/domain/qr_payload_test.dart
+++ b/test/features/game/domain/qr_payload_test.dart
@@ -1,0 +1,105 @@
+import 'package:cops_and_robbers/features/game/domain/qr_payload.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('QrPayload.freshFor', () {
+    test('참가자 ID를 보존하고 만료시각을 now + ttl로 설정한다', () {
+      final now = DateTime(2026, 4, 22, 12, 0, 0);
+
+      final payload = QrPayload.freshFor(
+        participantId: 102,
+        now: now,
+        ttl: const Duration(seconds: 30),
+      );
+
+      expect(payload.participantId, 102);
+      expect(payload.expiresAt, DateTime(2026, 4, 22, 12, 0, 30));
+    });
+  });
+
+  group('QrPayload 라운드트립 (toRaw ↔ tryParse)', () {
+    test('toRaw 결과를 tryParse로 파싱하면 원본과 동등하다', () {
+      final original = QrPayload(
+        participantId: 102,
+        expiresAt: DateTime.fromMillisecondsSinceEpoch(1729508430000),
+      );
+
+      final parsed = QrPayload.tryParse(original.toRaw());
+
+      expect(parsed, isNotNull);
+      expect(parsed!.participantId, original.participantId);
+      expect(parsed.expiresAt, original.expiresAt);
+    });
+  });
+
+  group('QrPayload.tryParse 파싱 실패', () {
+    test('잘못된 JSON 문자열은 null을 반환한다', () {
+      expect(QrPayload.tryParse('not a json'), isNull);
+    });
+
+    test('최상위가 Map이 아니면 null을 반환한다', () {
+      expect(QrPayload.tryParse('[1, 2, 3]'), isNull);
+      expect(QrPayload.tryParse('42'), isNull);
+      expect(QrPayload.tryParse('"string"'), isNull);
+    });
+
+    test('pid 필드가 없으면 null을 반환한다', () {
+      expect(QrPayload.tryParse('{"exp": 1729508430000}'), isNull);
+    });
+
+    test('pid가 문자열이면 null을 반환한다', () {
+      expect(
+        QrPayload.tryParse('{"pid": "102", "exp": 1729508430000}'),
+        isNull,
+      );
+    });
+
+    test('exp 필드가 없으면 null을 반환한다', () {
+      expect(QrPayload.tryParse('{"pid": 102}'), isNull);
+    });
+
+    test('exp가 문자열이면 null을 반환한다', () {
+      expect(
+        QrPayload.tryParse('{"pid": 102, "exp": "1729508430000"}'),
+        isNull,
+      );
+    });
+
+    test('pid가 num(double) 타입이어도 int로 정규화하여 허용한다', () {
+      // 실제 JSON 파싱에서 정수가 num으로 들어올 수 있음
+      final parsed = QrPayload.tryParse(
+        '{"pid": 102, "exp": 1729508430000}',
+      );
+      expect(parsed, isNotNull);
+      expect(parsed!.participantId, 102);
+    });
+  });
+
+  group('QrPayload.isExpiredAt 만료 판정', () {
+    final payload = QrPayload(
+      participantId: 102,
+      expiresAt: DateTime(2026, 4, 22, 12, 0, 30),
+    );
+
+    test('expiresAt 1ms 이전은 유효하다', () {
+      expect(
+        payload.isExpiredAt(DateTime(2026, 4, 22, 12, 0, 29, 999)),
+        isFalse,
+      );
+    });
+
+    test('expiresAt과 정확히 같은 시각은 만료로 판정한다', () {
+      expect(
+        payload.isExpiredAt(DateTime(2026, 4, 22, 12, 0, 30)),
+        isTrue,
+      );
+    });
+
+    test('expiresAt 1ms 이후는 만료로 판정한다', () {
+      expect(
+        payload.isExpiredAt(DateTime(2026, 4, 22, 12, 0, 30, 1)),
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/features/game/domain/qr_payload_test.dart
+++ b/test/features/game/domain/qr_payload_test.dart
@@ -65,11 +65,19 @@ void main() {
       );
     });
 
-    test('pid가 num(double) 타입이어도 int로 정규화하여 허용한다', () {
-      // 실제 JSON 파싱에서 정수가 num으로 들어올 수 있음
-      final parsed = QrPayload.tryParse('{"pid": 102, "exp": 1729508430000}');
-      expect(parsed, isNotNull);
-      expect(parsed!.participantId, 102);
+    test('pid가 소수(fractional)면 null을 반환한다', () {
+      // fractional 값이 조용히 절삭되는 것을 방지하기 위해 int만 허용
+      expect(
+        QrPayload.tryParse('{"pid": 102.5, "exp": 1729508430000}'),
+        isNull,
+      );
+    });
+
+    test('exp가 소수(fractional)면 null을 반환한다', () {
+      expect(
+        QrPayload.tryParse('{"pid": 102, "exp": 1729508430000.5}'),
+        isNull,
+      );
     });
   });
 


### PR DESCRIPTION
## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->


## ✅ 테스트
---

- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * QR 코드에 30초 만료 시간 추가
  * QR 스캔 시 만료 여부 자동 검사 및 만료된 QR 사용 차단(새 QR 요청 안내)
  * 튜토리얼 텍스트 업데이트(경찰팀: “참가자 카드” 대신 “도둑의 QR”로 표현)

* **Tests**
  * QR 페이로드 동작(생성·직렬화·파싱·만료 판정)을 검증하는 테스트 스위트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->