### PR TITLE
refactor : Step 2 게임 설정 슬라이더 공용 컴포넌트 재사용 #253

### DIFF
--- a/lib/features/session/presentation/pages/game_settings_edit_page.dart
+++ b/lib/features/session/presentation/pages/game_settings_edit_page.dart
@@ -13,11 +13,11 @@ import '../../../../core/services/loading_message_service.dart';
 import '../../../../core/widgets/snackbars/app_snackbar.dart';
 import '../../../../core/widgets/buttons/app_button.dart';
 import '../../../../core/widgets/buttons/previous_button.dart';
-import '../../../../core/widgets/inputs/app_slider.dart';
 import '../../data/models/game_create_request_model.dart';
 import '../../data/models/game_settings_response.dart';
 import '../providers/session_provider.dart';
 import '../widgets/session_creation_steps/step_1_participant_settings_content.dart';
+import '../widgets/session_creation_steps/step_2_game_settings_content.dart';
 
 /// 게임 설정 수정 페이지
 ///
@@ -168,97 +168,21 @@ class _GameSettingsEditPageState extends ConsumerState<GameSettingsEditPage> {
 
                       SizedBox(height: AppSpacing.vertical8),
 
-                      // Step 2: 게임 규칙 설정 (인라인)
-                      AppSlider(
-                        label: '라운드 제한 시간',
-                        value: _roundDurationMinutes.toDouble(),
-                        min: 10,
-                        max: 180,
-                        unit: '분',
-                        divisions: 170,
-                        onChanged: (v) =>
-                            setState(() => _roundDurationMinutes = v.toInt()),
+                      // Step 2: 게임 규칙 설정 (공용 컴포넌트 재사용)
+                      Step2GameSettingsContent(
+                        roundDurationMinutes: _roundDurationMinutes,
+                        locationShareMinutes: _locationShareMinutes,
+                        policeWaitMinutes: _policeWaitMinutes,
+                        onRoundDurationChanged: (v) =>
+                            setState(() => _roundDurationMinutes = v),
+                        onLocationShareChanged: (v) =>
+                            setState(() => _locationShareMinutes = v),
+                        onPoliceWaitChanged: (v) =>
+                            setState(() => _policeWaitMinutes = v),
                         isDarkMode: isDark,
-                        backgroundColor: isDark
-                            ? AppColors.black900
-                            : AppColors.white,
-                        activeTrackColor: isDark
-                            ? AppColors.green800
-                            : AppColors.black800,
-                        thumbColor: isDark ? AppColors.green : AppColors.black,
-                        inactiveTrackColor: isDark
-                            ? AppColors.black800
-                            : AppColors.black100,
-                        valueColor: isDark ? AppColors.white : null,
                         valueTextStyle: isDark
                             ? AppTextStyles.robberLabel
                             : null,
-                        editable: true,
-                      ),
-
-                      SizedBox(height: AppSpacing.vertical8),
-
-                      AppSlider(
-                        label: '도둑 위치 공유 간격',
-                        value: _locationShareMinutes.toDouble(),
-
-                        /// TODO : 추후에 API 생기면 0으로 변경
-                        min: 1,
-                        max: 30,
-                        unit: '분',
-                        divisions: 30,
-                        onChanged: (v) =>
-                            setState(() => _locationShareMinutes = v.toInt()),
-                        isDarkMode: isDark,
-                        warningText: _locationShareMinutes == 0
-                            ? '도둑의 위치가 공유되지 않아요!'
-                            : null,
-                        backgroundColor: isDark
-                            ? AppColors.black900
-                            : AppColors.white,
-                        activeTrackColor: isDark
-                            ? AppColors.green800
-                            : AppColors.black800,
-                        thumbColor: isDark ? AppColors.green : AppColors.black,
-                        inactiveTrackColor: isDark
-                            ? AppColors.black800
-                            : AppColors.black100,
-                        valueColor: isDark ? AppColors.white : null,
-                        valueTextStyle: isDark
-                            ? AppTextStyles.robberLabel
-                            : null,
-                        editable: true,
-                      ),
-
-                      SizedBox(height: AppSpacing.vertical8),
-
-                      AppSlider(
-                        label: '경찰 시작 시간',
-                        value: _policeWaitMinutes.toDouble(),
-                        min: 1,
-                        max: 10,
-                        unit: '분',
-                        divisions: 9,
-                        displayPrefix: '도둑 시작 후 ',
-                        displaySuffix: ' 뒤',
-                        onChanged: (v) =>
-                            setState(() => _policeWaitMinutes = v.toInt()),
-                        isDarkMode: isDark,
-                        backgroundColor: isDark
-                            ? AppColors.black900
-                            : AppColors.white,
-                        activeTrackColor: isDark
-                            ? AppColors.green800
-                            : AppColors.black800,
-                        thumbColor: isDark ? AppColors.green : AppColors.black,
-                        inactiveTrackColor: isDark
-                            ? AppColors.black800
-                            : AppColors.black100,
-                        valueColor: isDark ? AppColors.white : null,
-                        valueTextStyle: isDark
-                            ? AppTextStyles.robberLabel
-                            : null,
-                        editable: true,
                       ),
                     ],
                   ),

--- a/lib/features/session/presentation/widgets/session_creation_steps/step_2_game_settings_content.dart
+++ b/lib/features/session/presentation/widgets/session_creation_steps/step_2_game_settings_content.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../../../core/constants/app_colors.dart';
 import '../../../../../core/constants/spacing_and_radius.dart';
 import '../../../../../core/widgets/inputs/app_slider.dart';
 
@@ -19,6 +20,7 @@ class Step2GameSettingsContent extends StatelessWidget {
     required this.onLocationShareChanged,
     required this.onPoliceWaitChanged,
     this.isDarkMode = false,
+    this.valueTextStyle,
     this.roundDurationKey,
     this.locationShareKey,
     this.policeWaitKey,
@@ -49,6 +51,12 @@ class Step2GameSettingsContent extends StatelessWidget {
   /// 다크 모드 여부
   final bool isDarkMode;
 
+  /// 값 텍스트 스타일 오버라이드 (null이면 AppSlider 기본값 사용)
+  ///
+  /// 다크모드(도둑 팀)에서 Moneygraphy 글꼴을 적용하기 위한 prop.
+  /// Step 1과 동일한 시그니처를 유지한다.
+  final TextStyle? valueTextStyle;
+
   /// 튜토리얼 하이라이트용 — 라운드 제한 시간 슬라이더
   final GlobalKey? roundDurationKey;
 
@@ -78,6 +86,8 @@ class Step2GameSettingsContent extends StatelessWidget {
           divisions: 170, // 10~180, 1분 단위
           onChanged: (value) => onRoundDurationChanged(value.toInt()),
           isDarkMode: isDarkMode,
+          valueColor: isDarkMode ? AppColors.white : null,
+          valueTextStyle: valueTextStyle,
           editable: true,
         ),
 
@@ -96,6 +106,8 @@ class Step2GameSettingsContent extends StatelessWidget {
           divisions: 30, // 1~30, 1분 단위
           onChanged: (value) => onLocationShareChanged(value.toInt()),
           isDarkMode: isDarkMode,
+          valueColor: isDarkMode ? AppColors.white : null,
+          valueTextStyle: valueTextStyle,
           editable: true,
           warningText: locationShareMinutes == 0 ? '도둑의 위치가 공유되지 않아요!' : null,
         ),
@@ -115,6 +127,8 @@ class Step2GameSettingsContent extends StatelessWidget {
           displaySuffix: " 뒤",
           onChanged: (value) => onPoliceWaitChanged(value.toInt()),
           isDarkMode: isDarkMode,
+          valueColor: isDarkMode ? AppColors.white : null,
+          valueTextStyle: valueTextStyle,
           editable: true,
         ),
       ],


### PR DESCRIPTION
- 편집 페이지의 inline 슬라이더 3개를 Step2GameSettingsContent 호출로 교체
- Step2GameSettingsContent에 valueTextStyle prop 추가 (Step 1과 대칭)
- 다크모드(도둑팀) 값 색상을 흰색으로 통일하여 Step 1·편집 페이지와 일관성 확보

## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->


## ✅ 테스트
---

- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료
