### PR TITLE
fix : 게임 진입 시 이전 발자국 노출 버그 수정 #289

### DIFF
--- a/lib/features/game/presentation/pages/game_page.dart
+++ b/lib/features/game/presentation/pages/game_page.dart
@@ -195,7 +195,7 @@ class _GamePageState extends ConsumerState<GamePage>
     if (!mounted) return;
 
     if (canAccess) {
-      _initGameConnections();
+      await _initGameConnections();
       return;
     }
 
@@ -237,15 +237,24 @@ class _GamePageState extends ConsumerState<GamePage>
   }
 
   /// 게임 연결 및 초기화 (위치 권한 확보 후 실행)
-  void _initGameConnections() {
+  ///
+  /// STOMP 연결 시 `_fetchLastRobberLocations` 가드가 `participantInfo`의
+  /// gameStartTime/policeWaitMinutes에 의존하므로, 반드시 설정 로드 후에
+  /// STOMP 연결을 시작한다. 로비 경유 진입에서는 이미 설정이 있어 지연 없음.
+  /// splash 재진입 시에만 settings API 1회 호출 비용이 발생한다.
+  Future<void> _initGameConnections() async {
     if (_isLocationPermissionDenied) {
       setState(() => _isLocationPermissionDenied = false);
     }
     _connectChat();
+
+    await _initSettingsFromApiIfNeeded();
+    if (!mounted) return;
+
     _connectGameEvents();
     _loadGameArea();
     _showPoliceTimerIfNeeded();
-    _initSettingsAndStartMessages();
+    _sendGameStartSystemMessages();
 
     // 게임 초기화 완료 후 튜토리얼 (첫 진입 시 1회만)
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -307,16 +316,6 @@ class _GamePageState extends ConsumerState<GamePage>
       onFinish: () =>
           TutorialService.markCompleted(TutorialKeys.gameParticipants),
     );
-  }
-
-  /// 게임 설정 로드 후 게임 시작 시스템 메시지 발송
-  ///
-  /// 정상 진입(로비 경유): participantInfo에 이미 설정이 있으므로 즉시 판단.
-  /// terminate 재접속: API로 설정 로드 후 gameStartTime 기반으로 판단.
-  Future<void> _initSettingsAndStartMessages() async {
-    await _initSettingsFromApiIfNeeded();
-    if (!mounted) return;
-    _sendGameStartSystemMessages();
   }
 
   /// 앱 포그라운드 복귀 시 위치 권한 재확인

--- a/lib/features/game/presentation/providers/game_event_provider.dart
+++ b/lib/features/game/presentation/providers/game_event_provider.dart
@@ -698,7 +698,8 @@ class GameEventNotifier extends _$GameEventNotifier {
         _reconnectTimer?.cancel();
         _reconnectTimer = null;
         state = state.copyWith(errorMessage: null);
-        // 재연결 후 누락된 도둑 발자국 복구
+        // STOMP 유실 구간에서 놓친 LOCATION_REVEAL 복구.
+        // 실제 호출 여부 판단(경찰 대기 중 skip 등)은 메서드 내부 가드에서 수행.
         if (_gameId != null) _fetchLastRobberLocations(_gameId!);
       } else if (connState == StompConnectionState.disconnected) {
         if (!_intentionalDisconnect && !_isHandlingError) {
@@ -715,12 +716,38 @@ class GameEventNotifier extends _$GameEventNotifier {
     });
   }
 
-  /// 재연결 후 마지막으로 공개된 도둑 위치를 조회하여 발자국 복구
+  /// 마지막으로 공개된 도둑 위치를 조회하여 발자국 복구
   ///
-  /// STOMP 연결 유실 중 LOCATION_REVEAL 이벤트를 놓쳤을 때 호출.
-  /// 빈 배열(아직 공개 전)이면 상태 변경 없이 무시.
-  /// await 중 dispose되거나 새 LOCATION_REVEAL이 도착한 경우 덮어쓰지 않음.
+  /// STOMP 연결 유실(네트워크 끊김, 앱 백그라운드/종료 후 재진입) 구간에서
+  /// 놓친 LOCATION_REVEAL 이벤트를 서버 조회로 보정한다.
+  ///
+  /// 가드: 경찰 이동 시작 시각(= `gameStartTime + policeWaitMinutes`) 이전에는
+  /// reveal이 발생할 수 없으므로 호출 자체를 skip한다. 그 이전에 호출하면
+  /// 서버가 이전 게임 잔존/스테일 데이터를 반환해도 초기 UI에 노출될 위험이 있다.
+  /// `participantInfo`는 `game_page.dart`에서 STOMP 연결 전에 로드되도록 보장한다.
+  ///
+  /// 빈 배열이면 상태 변경 없이 무시. await 중 dispose되거나 새 LOCATION_REVEAL이
+  /// 도착한 경우 덮어쓰지 않음.
   Future<void> _fetchLastRobberLocations(int gameId) async {
+    // 경찰 이동 시작 전에는 reveal 발생 불가 → API 호출 자체를 skip.
+    final participantInfo = ref.read(gameParticipantNotifierProvider);
+    final gameStartTimeStr = participantInfo?.gameStartTime;
+    final policeWaitMinutes = participantInfo?.policeWaitMinutes;
+    if (gameStartTimeStr == null || policeWaitMinutes == null) {
+      debugPrint('[GameEventNotifier] ⏭️ 발자국 복구 skip (게임 설정 미로드)');
+      return;
+    }
+    final startTime = DateTime.tryParse(gameStartTimeStr);
+    if (startTime == null) {
+      debugPrint('[GameEventNotifier] ⏭️ 발자국 복구 skip (startTime 파싱 실패)');
+      return;
+    }
+    final policeMoveTime = startTime.add(Duration(minutes: policeWaitMinutes));
+    if (DateTime.now().isBefore(policeMoveTime)) {
+      debugPrint('[GameEventNotifier] ⏭️ 발자국 복구 skip (경찰 대기 중)');
+      return;
+    }
+
     // fetch 시작 시점의 reveal 타임스탬프 캡처 (race condition 방지)
     final preRevealTime = state.lastLocationRevealTime;
     try {

--- a/lib/features/game/presentation/providers/game_event_provider.g.dart
+++ b/lib/features/game/presentation/providers/game_event_provider.g.dart
@@ -47,7 +47,7 @@ final gameSystemApiProvider = AutoDisposeProvider<GameSystemApi>.internal(
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
 typedef GameSystemApiRef = AutoDisposeProviderRef<GameSystemApi>;
-String _$gameEventNotifierHash() => r'1132aec41fa58fb07ea29c9ac15e922a741ea28b';
+String _$gameEventNotifierHash() => r'3a81d8fa6b8b29e427a07ba74215b7e68b049335';
 
 /// 게임 이벤트 상태 관리 Notifier
 ///


### PR DESCRIPTION
- _fetchLastRobberLocations에 경찰 이동 시작 시각 기반 가드 추가로 reveal 발생 전 서버 스테일 응답 차단
- STOMP 연결 전에 participantInfo 로드 보장하도록 _initGameConnections 순서 조정
- 앱 완전 종료 후 재진입 시에도 발자국 복구가 정상 동작하도록 보장

## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->


## ✅ 테스트
---

- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 게임 시작 시 초기화 시퀀싱을 개선하여 안정적인 연결 처리 강화
  * 네트워크 재연결 시 게임 상태 복구 로직을 최적화하여 더 빠른 동기화 실현

<!-- end of auto-generated comment: release notes by coderabbit.ai -->