### PR TITLE
fix : 게임 종료 시 참가자 목록 도둑 SVG가 ready로 바뀌는 문제 수정 #294

### DIFF
--- a/lib/features/game/presentation/pages/game_page.dart
+++ b/lib/features/game/presentation/pages/game_page.dart
@@ -1000,14 +1000,13 @@ class _GamePageState extends ConsumerState<GamePage>
     _gameOverDialogShown = true;
 
     // GAME_OVER 이벤트 state에서 gameResultId 캡처.
-    // 아래 disconnect()가 state를 const GameEventState()로 리셋하므로,
-    // 반드시 disconnect 호출 전에 읽어야 결과 다이얼로그에 전달할 수 있다.
     final gameResultId = ref.read(gameEventNotifierProvider).gameResultId;
 
     // 채팅 알림 상태 초기화 (다음 게임에서 기본값 ON으로 시작)
     ref.invalidate(chatNotificationEnabledProvider);
-    // STOMP 구독 즉시 해제 (늦게 도달하는 이벤트 차단)
-    // NOTE: 내부에서 state 리셋 수행 — 이후에는 state 기반 값(gameResultId 등) 읽기 금지
+    // STOMP 구독 즉시 해제 (늦게 도달하는 이벤트 차단).
+    // disconnect()는 시각 상태(arrestedParticipantIds 등)를 보존하므로,
+    // 참가자 목록 오버레이는 마지막 체포 스냅샷을 유지한다.
     ref.read(gameEventNotifierProvider.notifier).disconnect();
     // 혹시 열려있는 다른 팝업/다이얼로그 모두 닫기
     if (mounted) {

--- a/lib/features/game/presentation/providers/game_event_provider.dart
+++ b/lib/features/game/presentation/providers/game_event_provider.dart
@@ -324,6 +324,13 @@ class GameEventNotifier extends _$GameEventNotifier {
   }
 
   /// 의도적 연결 해제
+  ///
+  /// STOMP 구독과 내부 타이머만 정리하고 시각 상태
+  /// ([arrestedParticipantIds]·[escapedParticipantIds]·[robberLocations] 등)는
+  /// 보존한다. 게임 종료 시퀀스에서 참가자 목록 오버레이가 마지막 체포 스냅샷을
+  /// 그대로 유지하도록 하기 위함.
+  ///
+  /// 전체 상태 초기화는 provider autoDispose 에 맡긴다 (페이지 dispose 시 자동 정리).
   void disconnect() {
     _intentionalDisconnect = true;
     _reconnectTimer?.cancel();
@@ -342,7 +349,10 @@ class GameEventNotifier extends _$GameEventNotifier {
     _gameId = null;
 
     ref.read(gameEventStompDatasourceProvider).disconnect();
-    state = const GameEventState();
+    state = state.copyWith(
+      connectionState: StompConnectionState.disconnected,
+      errorMessage: null,
+    );
   }
 
   /// 도둑 체포 API 호출 (경찰 전용)


### PR DESCRIPTION
- GameEventNotifier.disconnect() 가 state 전체 리셋 대신 연결 상태만 갱신하도록 변경
- arrestedParticipantIds 등 시각 상태가 보존되어 참가자 오버레이가 jailed 스냅샷 유지
- game_page _showGameOverDialog 의 stale 주석 정리

## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->


## ✅ 테스트
---

- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 게임 연결 해제 시 UI 오버레이 상태 관리를 개선했습니다. 게임 오버 화면이 더욱 안정적으로 표시됩니다.

* **문서**
  * 게임 연결 끊김 시 상태 보존 동작에 대한 설명을 명확히 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->