### PR TITLE
20260430 #308 대기방 튜토리얼을 팀과 무관하게 1회만 노출

### DIFF
--- a/lib/core/services/tutorial/tutorial_keys.dart
+++ b/lib/core/services/tutorial/tutorial_keys.dart
@@ -7,11 +7,11 @@ class TutorialKeys {
   static const setupPlayground = 'tutorial_setup_playground';
   static const createStep2 = 'tutorial_create_step2';
 
-  // 대기실 튜토리얼: 팀별로 1회씩 노출되도록 키를 분리.
-  // 경찰 시점과 도둑 시점은 타겟 위젯(반대 팀 첫 슬롯)이 물리적으로 달라서
-  // 같은 키 하나로 묶으면 한쪽을 본 사용자에게 반대편 안내가 사라진다.
-  static const waitingRoomPolice = 'tutorial_waiting_room_police';
-  static const waitingRoomRobber = 'tutorial_waiting_room_robber';
+  // 대기실 튜토리얼: 역할(경찰/도둑) 무관 사용자당 1회만 노출.
+  // 모든 스텝(팀 변경·초대 코드·게임 설정·준비 버튼)이 양 팀에서 동일한
+  // 안내이므로 팀별 분리가 불필요. 1번 스텝 타겟만 "현재 팀의 반대 팀 첫
+  // 빈 슬롯"으로 호출 시점의 team 값으로 결정된다(키와 무관).
+  static const waitingRoom = 'tutorial_waiting_room';
 
   static const game = 'tutorial_game';
   static const gameParticipants = 'tutorial_game_participants';
@@ -21,22 +21,13 @@ class TutorialKeys {
   static const batteryOptNotice = 'tutorial_battery_opt_notice';
   static const batteryImpactNotice = 'tutorial_battery_impact_notice';
 
-  /// 팀 문자열('POLICE' | 'ROBBER')에 대응하는 대기실 튜토리얼 키.
-  /// 알 수 없는 값/`null`은 `null`을 반환하므로 호출부에서 가드해야 한다.
-  static String? waitingRoomByTeam(String? team) {
-    if (team == 'POLICE') return waitingRoomPolice;
-    if (team == 'ROBBER') return waitingRoomRobber;
-    return null;
-  }
-
   /// 전체 키 목록 (초기화 시 사용)
   static const all = [
     home,
     createStep0,
     setupPlayground,
     createStep2,
-    waitingRoomPolice,
-    waitingRoomRobber,
+    waitingRoom,
     game,
     gameParticipants,
     batteryOptNotice,

--- a/lib/features/session/presentation/pages/waiting_room_page.dart
+++ b/lib/features/session/presentation/pages/waiting_room_page.dart
@@ -474,12 +474,11 @@ class _WaitingRoomPageState extends ConsumerState<WaitingRoomPage>
         await _showInviteCodeDialog();
       }
 
-      // 초기 튜토리얼 트리거.
-      // WidgetRef.listen 은 future changes 만 구독하므로, 호스트 방 만들기처럼
-      // WaitingRoomPage 진입 전에 setGameInfo 로 팀이 이미 확정된 플로우는
-      // listener 로 잡히지 않는다. 여기서 최종 팀 값으로 직접 호출한다.
-      // 초대 참여 플로우처럼 listener 가 먼저 트리거된 경우에는
-      // _isTutorialShowing 가드로 중복 호출이 차단된다.
+      // 튜토리얼 트리거 단일 진입점.
+      // 단일 키 정책으로 팀 변경 재트리거 리스너가 제거되었으므로, 본 호출이
+      // 유일한 진입 경로다. STOMP 재연결 등으로 _fetchAndInitParticipants 가
+      // 여러 번 호출되어도 _isTutorialShowing 가드와 isCompleted 가드로
+      // 중복 노출이 차단된다.
       if (mounted && myTeam != null) {
         _showTutorialIfNeeded(myTeam);
       }

--- a/lib/features/session/presentation/pages/waiting_room_page.dart
+++ b/lib/features/session/presentation/pages/waiting_room_page.dart
@@ -489,13 +489,14 @@ class _WaitingRoomPageState extends ConsumerState<WaitingRoomPage>
     }
   }
 
-  /// 대기실 튜토리얼 (팀별 1회)
+  /// 대기실 튜토리얼 (사용자당 1회)
   ///
   /// 참가자 데이터가 로딩된 이후 호출되며, 전달된 [team] 값 기준으로
   /// 반대 팀 `AddSlotCard` 를 가리키는 팀 변경 카드 스텝을 포함한다.
   /// 반대 팀 정원이 꽉 차서 `AddSlotCard` 가 렌더링되지 않은 경우 해당
-  /// 스텝은 스킵된다. 완료 상태는 팀별 키([TutorialKeys.waitingRoomPolice]
-  /// 또는 [TutorialKeys.waitingRoomRobber])에 저장된다.
+  /// 스텝은 스킵된다. 완료 상태는 단일 키 [TutorialKeys.waitingRoom] 에
+  /// 저장되며, 한 번 본 사용자는 팀을 바꾸거나 재입장해도 다시 노출되지
+  /// 않는다(설정의 "튜토리얼 초기화"로만 재노출).
   Future<void> _showTutorialIfNeeded(String team) async {
     // 이미 표시 중이면 STOMP 재연결 등에 의한 중복 호출을 무시한다.
     if (_isTutorialShowing) return;
@@ -505,8 +506,7 @@ class _WaitingRoomPageState extends ConsumerState<WaitingRoomPage>
     // 호출이 fallback 튜토리얼을 트리거하므로 누락 없음.
     if (_pendingInviteDialog || _isInviteDialogOpen) return;
 
-    final key = TutorialKeys.waitingRoomByTeam(team);
-    if (key == null) return; // 알 수 없는 팀 값 방어
+    const key = TutorialKeys.waitingRoom;
 
     final completed = await TutorialService.isCompleted(key);
     if (completed || !mounted || _isTutorialShowing) return;
@@ -521,26 +521,25 @@ class _WaitingRoomPageState extends ConsumerState<WaitingRoomPage>
     }
 
     // endOfFrame 대기 사이에 TEAM_UPDATE 가 들어와 팀이 바뀌었다면 이 경로는
-    // 낡은 값이므로 표시하지 않는다. listener 가 새 팀으로 재트리거하므로
-    // _isTutorialShowing 플래그는 건드리지 않고 조용히 종료한다.
+    // 낡은 값이므로 표시하지 않는다. 단일 키 정책으로 재트리거 리스너가
+    // 제거되었으므로 새 호출은 _fetchAndInitParticipants() 의 명시 경로에서만
+    // 발생한다. 낡은 값에서는 _isTutorialShowing 플래그를 해제하지 않고 조용히
+    // 종료한다 — 새 경로가 진행 중일 수 있다.
     final currentTeam = ref.read(gameParticipantNotifierProvider)?.team;
     if (currentTeam != team) return;
 
-    // 전달받은 team 기준으로 "반대 팀" AddSlotCard 하나만 안내.
+    // 1번 스텝 타겟: 현재 팀 기준 반대 팀의 첫 빈 AddSlotCard.
     final isPolice = team == 'POLICE';
     final opponentKey = isPolice
         ? _tutorialKeyAddSlotRobber
         : _tutorialKeyAddSlotPolice;
-    final changeTeamDescription = isPolice
-        ? '이 버튼을 눌러 도둑팀으로 이동할 수 있어요'
-        : '이 버튼을 눌러 경찰팀으로 이동할 수 있어요';
 
     final targets = <TutorialTarget>[
       // 팀 변경 카드 (반대 팀 AddSlotCard 가 렌더링된 경우에만)
       if (opponentKey.currentContext != null)
         AppTutorialStyle.target(
           keyTarget: opponentKey,
-          description: changeTeamDescription,
+          description: '이 버튼을 눌러 다른 팀으로 이동할 수 있어요',
           align: TutorialAlign.bottom,
         ),
       // 초대 코드 공유

--- a/lib/features/session/presentation/pages/waiting_room_page.dart
+++ b/lib/features/session/presentation/pages/waiting_room_page.dart
@@ -140,10 +140,9 @@ class _WaitingRoomPageState extends ConsumerState<WaitingRoomPage>
 
   /// 초대코드 다이얼로그가 화면에 떠 있는 동안 true.
   ///
-  /// 방장 플로우에서 [_showInviteCodeDialog] 실행 중 STOMP 이벤트나
-  /// `ref.listen(gameParticipantNotifierProvider)` 리스너가
-  /// [_showTutorialIfNeeded] 를 호출해 다이얼로그 위에 튜토리얼이
-  /// 오버레이되는 경쟁 상태를 막기 위한 가드.
+  /// 방장 플로우에서 [_showInviteCodeDialog] 실행 중 STOMP 이벤트로
+  /// 트리거된 [_showTutorialIfNeeded] 가 다이얼로그 위에 튜토리얼을
+  /// 오버레이하는 경쟁 상태를 막기 위한 가드.
   bool _isInviteDialogOpen = false;
   // ─────────────────────────────────────────────────────────────────────────
 
@@ -1148,48 +1147,6 @@ class _WaitingRoomPageState extends ConsumerState<WaitingRoomPage>
         if (!mounted) return;
         controller.refresh();
       });
-    });
-
-    // 대기실 튜토리얼 트리거:
-    //   - 팀이 처음 확정되는 시점(null → POLICE/ROBBER)에 초기 노출 트리거
-    //   - 팀 변경(POLICE ↔ ROBBER) 시점에 재트리거 (팀별 키 기준 미완료면 표시)
-    //   - 진행 중이면 현재 컨트롤러를 finish()로 종료하여 이전 팀 키를
-    //     markCompleted 처리한 뒤 새 팀 튜토리얼을 즉시 이어 실행
-    //
-    // 주의: WidgetRef.listen 은 future changes 만 구독하므로, 호스트 방
-    // 만들기 플로우처럼 WaitingRoomPage 진입 전에 setGameInfo(team:'POLICE')
-    // 가 이미 실행된 경우의 초기값은 여기서 잡지 못한다. 초기 노출은
-    // _fetchAndInitParticipants() 종료 시점의 명시적 호출이 담당한다.
-    ref.listen(gameParticipantNotifierProvider, (prev, next) {
-      final prevTeam = prev?.team;
-      final nextTeam = next?.team;
-      if (nextTeam == null) return;
-
-      final isInitial = prevTeam == null;
-      final isChanged = prevTeam != null && prevTeam != nextTeam;
-      if (!isInitial && !isChanged) return;
-
-      // 진행 중 튜토리얼이 있으면 종료하고 재표시 허용 플래그를 복구.
-      // finish() 는 onFinish 콜백을 통해 이전 팀 키를 markCompleted 처리한다.
-      // 주의: tutorial_coach_mark 의 finish() 가 onFinish 를 비동기로 호출할
-      // 경우 markCompleted 가 새 튜토리얼 시작 이후 실행될 수 있으나,
-      // markCompleted 는 저장만 수행하므로 기능/UX 오동작은 없다.
-      final controller = _tutorialController;
-      if (controller != null && controller.isShowing) {
-        controller.finish();
-        _tutorialController = null;
-        _isTutorialShowing = false;
-      } else {
-        // 컨트롤러는 아직 없지만 _showTutorialIfNeeded 가 endOfFrame 대기 중
-        // 플래그만 선점한 상태일 수 있다. 그 낡은 경로가 새 팀 튜토리얼 시작을
-        // 가드로 막지 않도록 플래그를 해제한다. (기존 경로는 endOfFrame 후
-        // team 재확인 가드에서 조용히 종료된다.)
-        _isTutorialShowing = false;
-      }
-
-      // 새 팀 기준 튜토리얼 체크 및 표시 (isCompleted 내부 체크로 이미 본
-      // 팀은 자연스럽게 skip 된다).
-      _showTutorialIfNeeded(nextTeam);
     });
 
     final participantsState = ref.watch(waitingRoomParticipantsProvider);

--- a/test/core/services/tutorial/tutorial_keys_test.dart
+++ b/test/core/services/tutorial/tutorial_keys_test.dart
@@ -2,43 +2,13 @@ import 'package:cops_and_robbers/core/services/tutorial/tutorial_keys.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  group('TutorialKeys.waitingRoomByTeam', () {
-    test('POLICE 입력 시 경찰 튜토리얼 키를 반환한다', () {
-      expect(
-        TutorialKeys.waitingRoomByTeam('POLICE'),
-        TutorialKeys.waitingRoomPolice,
-      );
+  group('TutorialKeys.waitingRoom', () {
+    test('단일 키 상수 값', () {
+      expect(TutorialKeys.waitingRoom, 'tutorial_waiting_room');
     });
 
-    test('ROBBER 입력 시 도둑 튜토리얼 키를 반환한다', () {
-      expect(
-        TutorialKeys.waitingRoomByTeam('ROBBER'),
-        TutorialKeys.waitingRoomRobber,
-      );
-    });
-
-    test('null 입력 시 null을 반환한다', () {
-      expect(TutorialKeys.waitingRoomByTeam(null), isNull);
-    });
-
-    test('알 수 없는 팀 문자열은 null을 반환한다', () {
-      expect(TutorialKeys.waitingRoomByTeam('SPECTATOR'), isNull);
-      expect(TutorialKeys.waitingRoomByTeam(''), isNull);
-      expect(TutorialKeys.waitingRoomByTeam('police'), isNull); // 소문자 불허
-    });
-  });
-
-  group('TutorialKeys.waitingRoomPolice / waitingRoomRobber', () {
-    test('경찰과 도둑 키는 서로 다른 문자열이다', () {
-      expect(
-        TutorialKeys.waitingRoomPolice,
-        isNot(equals(TutorialKeys.waitingRoomRobber)),
-      );
-    });
-
-    test('두 키 모두 all 목록에 포함된다', () {
-      expect(TutorialKeys.all, contains(TutorialKeys.waitingRoomPolice));
-      expect(TutorialKeys.all, contains(TutorialKeys.waitingRoomRobber));
+    test('TutorialKeys.all 에 포함된다', () {
+      expect(TutorialKeys.all, contains(TutorialKeys.waitingRoom));
     });
   });
 }


### PR DESCRIPTION
## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->


## ✅ 테스트
---

- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 대기실 튜토리얼 트리거 로직을 단일 흐름으로 통합하여 재트리거 및 경합 상황을 줄임
  * 팀별 분기 제거로 튜토리얼 완료 판정이 일관되게 동작하도록 안정성 향상
  * 빌드 수준의 리스닝 기반 재실행 로직을 제거해 예측 가능한 표시 동작 보장

* **기타**
  * 관련 단위 테스트를 단일 키 기준으로 정리 및 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->