### PR TITLE
20260430 #312 포그라운드 fcm 알림 표시 억제 stomp 재연결 자동 트리거

### DIFF
--- a/lib/core/services/fcm/firebase_messaging_service.dart
+++ b/lib/core/services/fcm/firebase_messaging_service.dart
@@ -160,13 +160,10 @@ class FirebaseMessagingService {
   /// Initialize Firebase Messaging and sets up all message listeners
   /// Firebase Messaging을 초기화하고 모든 메시지 리스너를 설정합니다
   Future<void> init() async {
-    // Handle FCM token
-    // FCM 토큰 처리
-    _handlePushNotificationsToken();
-
-    // Request user permission for notifications
-    // 알림 권한 요청
-    _requestPermission();
+    // Ensure permission is granted before fetching token
+    // Android 13+/iOS는 권한 부여 전 FCM 토큰이 null로 반환될 수 있음
+    await _requestPermission();
+    await _handlePushNotificationsToken();
 
     // iOS: 포그라운드에서는 시스템 배너/사운드/뱃지를 띄우지 않는다.
     // 게임 이벤트는 STOMP 인앱 배너로 이미 표시되며, 그 외 화면에서도

--- a/lib/core/services/fcm/firebase_messaging_service.dart
+++ b/lib/core/services/fcm/firebase_messaging_service.dart
@@ -218,37 +218,33 @@ class FirebaseMessagingService {
       debugPrint('📱 Full Device Info: $fullDeviceInfo');
     }
 
-    // 3. Try to get FCM token (may fail on iOS simulator)
-    // 3. FCM 토큰 가져오기 시도 (iOS 시뮬레이터에서는 실패할 수 있음)
+    // 3. Register token refresh listener BEFORE fetching the initial token
+    // 3. 초기 토큰 조회 전에 갱신 리스너 등록 (초기 토큰이 null이어도 이후 발급분 캡처 보장)
+    FirebaseMessaging.instance.onTokenRefresh
+        .listen((fcmToken) {
+          debugPrint('🔄 FCM token refreshed: $fcmToken');
+          debugPrint('✅ Updated token will be sent on next login.');
+        })
+        .onError((error) {
+          // Handle errors during token refresh
+          // 토큰 갱신 중 발생한 에러 처리
+          debugPrint('❌ Error refreshing FCM token: $error');
+        });
+
+    // 4. Try to get FCM token (may fail on iOS simulator)
+    // 4. FCM 토큰 가져오기 시도 (iOS 시뮬레이터에서는 실패할 수 있음)
     // getFcmToken()이 이미 try-catch 처리하므로 재사용
     final token = await getFcmToken();
 
-    // 4. Setup token refresh listener if token exists
-    // 4. 토큰이 있으면 갱신 리스너 등록
-    if (token != null) {
-      // Listen for token refresh events
-      // 토큰 갱신 이벤트 수신 대기
-      FirebaseMessaging.instance.onTokenRefresh
-          .listen((fcmToken) {
-            debugPrint('🔄 FCM token refreshed: $fcmToken');
-            debugPrint('✅ Updated token will be sent on next login.');
-          })
-          .onError((error) {
-            // Handle errors during token refresh
-            // 토큰 갱신 중 발생한 에러 처리
-            debugPrint('❌ Error refreshing FCM token: $error');
-          });
-    } else {
-      // Show helpful message for simulator users when token is null
-      // 시뮬레이터 사용자를 위한 안내 메시지
-      if (!isPhysical) {
-        debugPrint(
-          '📱 Note: FCM tokens are only available on physical iOS devices, not simulators',
-        );
-        debugPrint(
-          '💡 Device information is collected successfully, but push notifications require a real device',
-        );
-      }
+    // 5. Show helpful message for simulator users when token is null
+    // 5. 시뮬레이터 사용자를 위한 안내 메시지
+    if (token == null && !isPhysical) {
+      debugPrint(
+        '📱 Note: FCM tokens are only available on physical iOS devices, not simulators',
+      );
+      debugPrint(
+        '💡 Device information is collected successfully, but push notifications require a real device',
+      );
     }
   }
 

--- a/lib/core/services/fcm/firebase_messaging_service.dart
+++ b/lib/core/services/fcm/firebase_messaging_service.dart
@@ -51,6 +51,37 @@ class FirebaseMessagingService {
   static Stream<String> get contentCompletedStream =>
       _contentCompletedController.stream;
 
+  // ═══════════════════════════════════════════════════════════════════════
+  // 게임 시스템 이벤트 알림 Stream (STOMP 좀비 연결 자동 복구용)
+  // ═══════════════════════════════════════════════════════════════════════
+
+  /// 백엔드에서 게임 진행 중 발생하는 시스템 이벤트의 FCM data.type 값 집합.
+  ///
+  /// BE PR #84의 SystemEventType.name() 결과와 일치한다.
+  /// (ARREST, ESCAPE, GAME_OVER, ROBBER_LOCATION_REVEAL, POLICE_MOVE_START)
+  static const Set<String> _gameSystemEventTypes = {
+    'ARREST',
+    'ESCAPE',
+    'GAME_OVER',
+    'ROBBER_LOCATION_REVEAL',
+    'POLICE_MOVE_START',
+  };
+
+  /// 게임 시스템 이벤트 FCM 도착 시 발행되는 StreamController.
+  ///
+  /// 페이로드는 `data.type` 값(`ARREST` 등)을 그대로 전달한다.
+  /// 구독자(GameEventNotifier)는 이 신호를 받아 STOMP 좀비 연결 시
+  /// 자동 재연결을 트리거한다.
+  static final _gameSystemEventController =
+      StreamController<String>.broadcast();
+
+  /// 게임 시스템 이벤트 알림 Stream
+  ///
+  /// FCM이 도착했다는 것은 디바이스 푸시 채널이 살아있다는 신호이므로,
+  /// 같은 시점에 STOMP가 dead 상태라면 재연결을 시도할 좋은 트리거다.
+  static Stream<String> get gameSystemEventStream =>
+      _gameSystemEventController.stream;
+
   /// 백엔드 등록용 FCM 토큰을 가져옵니다
   ///
   /// 로그인 API 호출 시 이 메서드를 사용하여 FCM 토큰을 가져옵니다.
@@ -265,6 +296,13 @@ class FirebaseMessagingService {
         _contentCompletedController.add(contentId);
       }
     }
+
+    // 게임 시스템 이벤트(BE PR #84) — Stream으로 발행하여
+    // GameEventNotifier가 STOMP 좀비 연결 자동 복구 트리거로 활용한다.
+    if (messageType != null && _gameSystemEventTypes.contains(messageType)) {
+      debugPrint('[FCM] 게임 시스템 이벤트 수신: $messageType');
+      _gameSystemEventController.add(messageType);
+    }
   }
 
   /// Handles notification taps when app is opened from the background or terminated state
@@ -297,6 +335,7 @@ class FirebaseMessagingService {
   /// 앱 종료 시 호출하여 메모리 누수를 방지합니다.
   static void dispose() {
     _contentCompletedController.close();
+    _gameSystemEventController.close();
   }
 }
 

--- a/lib/core/services/fcm/firebase_messaging_service.dart
+++ b/lib/core/services/fcm/firebase_messaging_service.dart
@@ -1,11 +1,8 @@
 import 'dart:async';
-import 'dart:io' show Platform;
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
-import 'local_notifications_service.dart';
 import '../device/device_info_service.dart';
 import '../device/device_id_manager.dart';
-import '../vibration_service.dart';
 
 /// Firebase Cloud Messaging 서비스
 /// FCM 푸시 알림을 관리하고 메시지를 처리합니다
@@ -22,10 +19,6 @@ class FirebaseMessagingService {
   // Factory constructor to provide singleton instance
   // 싱글톤 인스턴스를 제공하는 팩토리 생성자
   factory FirebaseMessagingService.instance() => _instance;
-
-  // Reference to local notifications service for displaying notifications
-  // 알림 표시를 위한 로컬 알림 서비스 참조
-  LocalNotificationsService? _localNotificationsService;
 
   // ═══════════════════════════════════════════════════════════════════════
   // 콘텐츠 완료 알림 Stream (NotificationScreen용)
@@ -135,13 +128,7 @@ class FirebaseMessagingService {
 
   /// Initialize Firebase Messaging and sets up all message listeners
   /// Firebase Messaging을 초기화하고 모든 메시지 리스너를 설정합니다
-  Future<void> init({
-    required LocalNotificationsService localNotificationsService,
-  }) async {
-    // Init local notifications service
-    // 로컬 알림 서비스 초기화
-    _localNotificationsService = localNotificationsService;
-
+  Future<void> init() async {
     // Handle FCM token
     // FCM 토큰 처리
     _handlePushNotificationsToken();
@@ -150,14 +137,14 @@ class FirebaseMessagingService {
     // 알림 권한 요청
     _requestPermission();
 
-    // iOS: 포그라운드에서 FCM이 직접 시스템 배너/사운드/뱃지를 표시하도록 활성화
-    // (iOS는 UNUserNotificationCenter delegate가 하나뿐이라 FCM이 점유하므로,
-    //  flutter_local_notifications로 띄우면 같은 옵션의 영향을 받아 배너가 안 뜸)
+    // iOS: 포그라운드에서는 시스템 배너/사운드/뱃지를 띄우지 않는다.
+    // 게임 이벤트는 STOMP 인앱 배너로 이미 표시되며, 그 외 화면에서도
+    // 앱 진입 중에는 추가 시스템 알림이 사용자 흐름을 끊는다는 정책 결정.
     await FirebaseMessaging.instance
         .setForegroundNotificationPresentationOptions(
-          alert: true,
-          badge: true,
-          sound: true,
+          alert: false,
+          badge: false,
+          sound: false,
         );
 
     // Register handler for background messages (app terminated)
@@ -255,6 +242,12 @@ class FirebaseMessagingService {
 
   /// Handles messages received while the app is in the foreground
   /// 앱이 포그라운드 상태일 때 수신한 메시지를 처리합니다
+  ///
+  /// 정책: 앱이 포그라운드일 때는 시스템 배너·진동을 띄우지 않는다.
+  /// - iOS: setForegroundNotificationPresentationOptions(false) 로 차단
+  /// - Android: 로컬 알림 표시·진동 호출을 생략
+  /// 단, data 페이로드는 정상 처리하여 인앱 처리(콘텐츠 알림 Stream,
+  /// 게임 이벤트 Stream 등)는 그대로 동작시킨다.
   void _onForegroundMessage(RemoteMessage message) {
     // FCM 페이로드는 notification(제목/본문)과 data(커스텀 키-값)로 분리되어 있어 둘 다 출력
     debugPrint('[FCM] Foreground message received');
@@ -262,33 +255,14 @@ class FirebaseMessagingService {
     debugPrint('  notification.body : ${message.notification?.body}');
     debugPrint('  data: ${message.data}');
 
-    // 1. 커스텀 진동 피드백 (백그라운드에서는 OS 기본 진동도 안 오는 이슈가 있어
-    //    포그라운드라도 명시적으로 진동을 발생시켜 알림 인지율을 높임)
-    VibrationService.instance().messageReceived();
-
-    // 2. 백엔드 메시지 타입 확인 (data.type)
     final messageType = message.data['type'];
 
-    // 3. 콘텐츠 분석 완료 알림 처리
+    // 콘텐츠 분석 완료 알림 처리
     if (messageType == 'content_completed') {
       final contentId = message.data['id'];
       if (contentId != null) {
         debugPrint('[FCM] 콘텐츠 분석 완료 알림 수신: $contentId');
-        _contentCompletedController.add(contentId); // ✅ Stream으로 브로드캐스트
-      }
-    }
-
-    // 4. 로컬 알림 표시
-    //    Android: FCM이 포그라운드에서 자동 표시하지 않으므로 우리가 직접 띄움
-    //    iOS:    위 setForegroundNotificationPresentationOptions로 FCM이 직접 띄우므로 스킵 (중복 방지)
-    if (Platform.isAndroid) {
-      final notificationData = message.notification;
-      if (notificationData != null) {
-        _localNotificationsService?.showNotification(
-          notificationData.title,
-          notificationData.body,
-          message.data.toString(),
-        );
+        _contentCompletedController.add(contentId);
       }
     }
   }

--- a/lib/core/services/fcm/firebase_messaging_service.dart
+++ b/lib/core/services/fcm/firebase_messaging_service.dart
@@ -300,6 +300,10 @@ class FirebaseMessagingService {
 
   /// Handles notification taps when app is opened from the background or terminated state
   /// 앱이 백그라운드 또는 종료 상태에서 알림 탭으로 열렸을 때 처리합니다
+  ///
+  /// `getInitialMessage()`로 종료 상태에서 진입한 경우에도 동일하게 호출되므로,
+  /// 포그라운드 핸들러와 동일한 Stream 발행을 수행해 STOMP 좀비 연결
+  /// 자동 복구 트리거가 누락되지 않도록 한다.
   void _onMessageOpenedApp(RemoteMessage message) {
     // 알림 탭 시 notification 페이로드(제목/본문)와 data 페이로드를 분리해서 출력
     debugPrint('[FCM] Notification tapped (app opened)');
@@ -317,6 +321,13 @@ class FirebaseMessagingService {
         debugPrint('[FCM] 백그라운드에서 앱 열림 - contentId: $contentId');
         _contentCompletedController.add(contentId); // ✅ Stream으로 브로드캐스트
       }
+    }
+
+    // 게임 시스템 이벤트(BE PR #84) — 포그라운드 진입 시점에도 동일하게 발행하여
+    // GameEventNotifier가 STOMP 좀비 연결을 자동 복구할 수 있게 한다.
+    if (messageType != null && _gameSystemEventTypes.contains(messageType)) {
+      debugPrint('[FCM] 게임 시스템 이벤트 수신(알림 탭): $messageType');
+      _gameSystemEventController.add(messageType);
     }
 
     // TODO: Add navigation or specific handling based on message data

--- a/lib/features/game/presentation/providers/game_event_provider.dart
+++ b/lib/features/game/presentation/providers/game_event_provider.dart
@@ -8,6 +8,7 @@ import '../../../../core/constants/api_endpoints.dart';
 import '../../../../core/services/vibration_service.dart';
 import '../../../../core/services/lifecycle/app_lifecycle_service.dart';
 import '../../../../core/services/background/background_service_provider.dart';
+import '../../../../core/services/fcm/firebase_messaging_service.dart';
 import '../../../../core/constants/game_event_messages.dart';
 import '../../../../core/network/dio_client.dart';
 import '../../../auth/presentation/providers/token_provider.dart';
@@ -235,6 +236,7 @@ class GameEventNotifier extends _$GameEventNotifier {
   StreamSubscription<GameEventModel>? _eventSub;
   StreamSubscription<StompConnectionState>? _connectionSub;
   StreamSubscription<StompErrorInfo>? _errorSub;
+  StreamSubscription<String>? _fcmEventSub;
 
   int _authRetryCount = 0;
   static const _maxAuthRetries = 1;
@@ -256,15 +258,46 @@ class GameEventNotifier extends _$GameEventNotifier {
   @override
   GameEventState build() {
     ref.watch(gameEventStompDatasourceProvider);
+
+    // FCM 게임 시스템 이벤트(BE PR #84) 수신 시 STOMP 좀비 연결 자동 복구.
+    // 백오프 5회 소진 후 사용자가 재연결 모달을 방치한 케이스를
+    // FCM 도착 신호(=네트워크 살아있음)로 자동 복구한다.
+    _fcmEventSub = FirebaseMessagingService.gameSystemEventStream.listen(
+      _handleFcmGameEvent,
+    );
+
     ref.onDispose(() {
       _isDisposed = true;
       _eventSub?.cancel();
       _connectionSub?.cancel();
       _errorSub?.cancel();
+      _fcmEventSub?.cancel();
       _reconnectTimer?.cancel();
       _locationRevealBannerTimer?.cancel();
     });
     return const GameEventState();
+  }
+
+  /// FCM 게임 시스템 이벤트 도착 → STOMP 좀비 연결 자동 복구
+  ///
+  /// FCM이 도착했다는 것은 디바이스 푸시 채널이 살아있다 = 네트워크가 살아있다는
+  /// 신호다. 같은 시점에 STOMP가 dead 상태(`error`/`disconnected`)라면
+  /// `manualReconnect()`로 자동 복구한다. `connecting`/`connected` 상태이면
+  /// 정상 동작 중이므로 흔들지 않는다.
+  void _handleFcmGameEvent(String eventType) {
+    if (_isDisposed || _intentionalDisconnect || _gameId == null) return;
+
+    final connState = state.connectionState;
+    if (connState != StompConnectionState.error &&
+        connState != StompConnectionState.disconnected) {
+      return;
+    }
+
+    debugPrint(
+      '[GameEventNotifier] 📨 FCM($eventType) 수신 + STOMP $connState '
+      '→ 자동 재연결 시도',
+    );
+    manualReconnect();
   }
 
   /// STOMP 연결 후 게임 이벤트 구독

--- a/lib/features/game/presentation/providers/game_event_provider.dart
+++ b/lib/features/game/presentation/providers/game_event_provider.dart
@@ -284,7 +284,11 @@ class GameEventNotifier extends _$GameEventNotifier {
   /// 신호다. 같은 시점에 STOMP가 dead 상태(`error`/`disconnected`)라면
   /// `manualReconnect()`로 자동 복구한다. `connecting`/`connected` 상태이면
   /// 정상 동작 중이므로 흔들지 않는다.
-  void _handleFcmGameEvent(String eventType) {
+  ///
+  /// `manualReconnect()` 내부의 토큰 조회/재연결에서 예외가 던져질 수 있으므로
+  /// await + try-catch로 unhandled async error를 차단한다. 자동 복구 경로라
+  /// state는 흔들지 않고 로그만 남긴다(STOMP는 이미 error/disconnected 상태).
+  Future<void> _handleFcmGameEvent(String eventType) async {
     if (_isDisposed || _intentionalDisconnect || _gameId == null) return;
 
     final connState = state.connectionState;
@@ -297,7 +301,12 @@ class GameEventNotifier extends _$GameEventNotifier {
       '[GameEventNotifier] 📨 FCM($eventType) 수신 + STOMP $connState '
       '→ 자동 재연결 시도',
     );
-    manualReconnect();
+    try {
+      await manualReconnect();
+    } catch (e, stack) {
+      debugPrint('[GameEventNotifier] ❌ FCM 트리거 자동 재연결 실패: $e');
+      debugPrint('$stack');
+    }
   }
 
   /// STOMP 연결 후 게임 이벤트 구독

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -121,10 +121,8 @@ void main() async {
   // 4. 로컬 알림 서비스 초기화 (Firebase와 독립적)
   // 4. Initialize local notifications (independent from Firebase)
   // ============================================================
-  LocalNotificationsService? localNotificationsService;
   try {
-    localNotificationsService = LocalNotificationsService.instance();
-    await localNotificationsService.init();
+    await LocalNotificationsService.instance().init();
     debugPrint('✅ Local notifications initialized successfully');
   } catch (e, stackTrace) {
     debugPrint('❌ Local notifications initialization failed: $e');
@@ -134,14 +132,12 @@ void main() async {
   }
 
   // ============================================================
-  // 5. FCM 서비스 초기화 (Firebase + 로컬 알림 필요)
-  // 5. Initialize FCM (requires Firebase + Local notifications)
+  // 5. FCM 서비스 초기화 (Firebase 의존)
+  // 5. Initialize FCM (requires Firebase)
   // ============================================================
-  if (isFirebaseInitialized && localNotificationsService != null) {
+  if (isFirebaseInitialized) {
     try {
-      await FirebaseMessagingService.instance().init(
-        localNotificationsService: localNotificationsService,
-      );
+      await FirebaseMessagingService.instance().init();
       debugPrint('✅ FCM initialized successfully');
     } catch (e, stackTrace) {
       debugPrint('❌ FCM initialization failed: $e');
@@ -150,12 +146,7 @@ void main() async {
       // Continue execution (app works without remote push)
     }
   } else {
-    if (!isFirebaseInitialized) {
-      debugPrint('⚠️ FCM skipped (Firebase not initialized)');
-    }
-    if (localNotificationsService == null) {
-      debugPrint('⚠️ FCM skipped (Local notifications not initialized)');
-    }
+    debugPrint('⚠️ FCM skipped (Firebase not initialized)');
   }
 
   runApp(


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->
- 포그라운드 FCM 시스템 알림 억제: iOS 배너·사운드·뱃지, Android 로컬 알림·진동 호출 제거. STOMP 인앱 배너와 중복되는 시스템 알림을 차단해 사용자 흐름 끊김 방지 (data 페이로드 처리는 유지)

- FCM 수신 시 STOMP 좀비 연결 자동 재연결: STOMP가 `error`/`disconnected` 상태일 때, FCM 도착(=네트워크 살아있음 신호)을 트리거로 `manualReconnect()` 호출. 백오프 소진 후 재연결 모달이 방치된 케이스 자동 복구

- FCM init 순서 보정: 권한 결과를 먼저 await 후 토큰 조회. Android 13+/iOS 첫 실행 시 토큰이 `null`로 반환되어 백엔드에 빈 토큰이 등록되던 잠재 이슈 차단

## ✅ 테스트

- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 게임 시스템 이벤트(체포, 탈출, 게임 종료 등)에 대한 새로운 이벤트 스트림 추가

* **개선 사항**
  * 인앱 메시지 처리 개선으로 더 정확한 데이터 라우팅
  * 연결 상태가 불안정할 때 자동 재연결 메커니즘 강화
  * 시스템 알림 동작 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->