### PR TITLE
20260505 #330 안드로이드 3 button 네비 환경에서 채팅이 우측 액션 버튼을 가리는 문제

### DIFF
--- a/lib/features/chat/presentation/widgets/chat_overlay.dart
+++ b/lib/features/chat/presentation/widgets/chat_overlay.dart
@@ -19,6 +19,17 @@ import 'chat_input_bar.dart';
 import 'chat_message_list.dart';
 import 'chat_preview_card.dart';
 
+/// ChatOverlay collapsed 시트의 시스템 inset 제외 고정 부분 높이 (논리 dp).
+///
+/// 시트 상단부 합계: 드래그 핸들(28) + 핸들↔입력바 간격(8) + 입력바(64)
+///                  + 입력바 아래 안전 여백(12) = 112.
+/// 시스템 네비 바 inset(`MediaQuery.viewPadding.bottom`)은 호출 측에서
+/// 별도로 더해야 한다.
+///
+/// 같은 게임 화면 위에 절대 좌표로 떠 있는 위젯(우측 액션 버튼 등)이
+/// 채팅 시트와 충돌하지 않게 정렬할 때 이 상수를 단일 진실 공급원으로 참조한다.
+const double kChatOverlayCollapsedFixedHeight = 112.0;
+
 /// 채팅 오버레이 위젯
 ///
 /// 게임 화면 하단에 표시되는 채팅 UI입니다.
@@ -229,11 +240,12 @@ class _ChatOverlayState extends ConsumerState<ChatOverlay> {
     final bottomMargin = (isKeyboardOpen && !isKeyboardClosing)
         ? keyboardHeight
         : safeBottomMargin;
+    // collapsed 시트 총 높이 = inset 제외 고정 부분(상단 핸들 + 입력바 + 내부 여백)
+    //                          + 시스템 inset(viewPadding.bottom 또는 fallback)
+    // 고정 부분은 file-level [kChatOverlayCollapsedFixedHeight]를 단일 공급원으로 사용한다.
     final collapsedHeight =
-        _dragHandleHeight.h +
-        AppSpacing.vertical8 +
-        _inputBarHeight.h +
-        safeBottomMargin;
+        kChatOverlayCollapsedFixedHeight.h +
+        (bottomPadding > 0 ? bottomPadding : _fallbackBottomPadding.h);
     final expandedMinHeight =
         _dragHandleHeight.h +
         _titleAreaHeight.h +

--- a/lib/features/game/presentation/pages/game_page.dart
+++ b/lib/features/game/presentation/pages/game_page.dart
@@ -96,7 +96,10 @@ class _GamePageState extends ConsumerState<GamePage>
   final _tutorialKeyMapReturn = GlobalKey();
   final _tutorialKeyQrButton = GlobalKey();
 
-  /// 채팅 시트 상단(collapsed)과 우측 액션 버튼 하단 사이의 시각 여백 (논리 dp).
+  /// 채팅 시트 collapsed 상단과 우측 액션 버튼 하단 사이의 **고정 시각 여백** (논리 dp).
+  ///
+  /// 시스템 네비 inset(`MediaQuery.viewPadding.bottom`)에 따라 변하지 않는 고정값이다.
+  /// inset은 별도로 더해지며 이 상수에는 포함되지 않는다.
   static const double _kActionButtonChatGap = 45.0;
 
   bool _showParticipants = false;

--- a/lib/features/game/presentation/pages/game_page.dart
+++ b/lib/features/game/presentation/pages/game_page.dart
@@ -1444,6 +1444,12 @@ class _GamePageState extends ConsumerState<GamePage>
       );
     }
 
+    // 시스템 네비게이션 바(안드로이드 3-button 등)의 하단 inset.
+    // ChatOverlay는 viewPadding.bottom을 반영해 시트가 위로 밀리는 반면,
+    // 우측 액션 버튼(및 개발용 디버그 FAB)은 절대 좌표(bottom: 157.h)라
+    // inset이 누락된다. 같은 inset을 더해 채팅 시트와 동일 기준으로 정렬한다.
+    final bottomInset = MediaQuery.of(context).viewPadding.bottom;
+
     return Scaffold(
       resizeToAvoidBottomInset: false,
       body: Stack(
@@ -1536,7 +1542,7 @@ class _GamePageState extends ConsumerState<GamePage>
           if (_showParticipants)
             Positioned(
               right: 20.w,
-              bottom: 157.h,
+              bottom: 157.h + bottomInset,
               child: Column(
                 children: [
                   SvgIconButton(
@@ -1556,7 +1562,7 @@ class _GamePageState extends ConsumerState<GamePage>
           else
             Positioned(
               right: 20.w,
-              bottom: 157.h,
+              bottom: 157.h + bottomInset,
               child: Column(
                 children: [
                   SvgIconButton(
@@ -1613,7 +1619,7 @@ class _GamePageState extends ConsumerState<GamePage>
           if (kDebugMode)
             Positioned(
               left: 12.w,
-              bottom: 157.h,
+              bottom: 157.h + bottomInset,
               child: FloatingActionButton(
                 heroTag: 'game_debug',
                 mini: true,

--- a/lib/features/game/presentation/pages/game_page.dart
+++ b/lib/features/game/presentation/pages/game_page.dart
@@ -96,6 +96,9 @@ class _GamePageState extends ConsumerState<GamePage>
   final _tutorialKeyMapReturn = GlobalKey();
   final _tutorialKeyQrButton = GlobalKey();
 
+  /// 채팅 시트 상단(collapsed)과 우측 액션 버튼 하단 사이의 시각 여백 (논리 dp).
+  static const double _kActionButtonChatGap = 45.0;
+
   bool _showParticipants = false;
   bool _gameOverDialogShown = false;
   bool _isCheckingGameStatus = false;
@@ -1444,11 +1447,18 @@ class _GamePageState extends ConsumerState<GamePage>
       );
     }
 
-    // 시스템 네비게이션 바(안드로이드 3-button 등)의 하단 inset.
-    // ChatOverlay는 viewPadding.bottom을 반영해 시트가 위로 밀리는 반면,
-    // 우측 액션 버튼(및 개발용 디버그 FAB)은 절대 좌표(bottom: 157.h)라
-    // inset이 누락된다. 같은 inset을 더해 채팅 시트와 동일 기준으로 정렬한다.
+    // 우측 액션 버튼(및 개발용 디버그 FAB)이 채팅 시트와 겹치지 않게 정렬할 bottom.
+    //
+    // = 채팅 시트 collapsed 고정 부분([kChatOverlayCollapsedFixedHeight])
+    // + 시각 여백([_kActionButtonChatGap])
+    // + 시스템 네비 inset(`MediaQuery.viewPadding.bottom`, 안드로이드 3-button 등)
+    //
+    // ChatOverlay 측이 inset을 자동 흡수하므로 액션 버튼도 같은 inset을 더해 정렬한다.
     final bottomInset = MediaQuery.of(context).viewPadding.bottom;
+    final actionButtonBottom =
+        kChatOverlayCollapsedFixedHeight.h +
+        _kActionButtonChatGap.h +
+        bottomInset;
 
     return Scaffold(
       resizeToAvoidBottomInset: false,
@@ -1542,7 +1552,7 @@ class _GamePageState extends ConsumerState<GamePage>
           if (_showParticipants)
             Positioned(
               right: 20.w,
-              bottom: 157.h + bottomInset,
+              bottom: actionButtonBottom,
               child: Column(
                 children: [
                   SvgIconButton(
@@ -1562,7 +1572,7 @@ class _GamePageState extends ConsumerState<GamePage>
           else
             Positioned(
               right: 20.w,
-              bottom: 157.h + bottomInset,
+              bottom: actionButtonBottom,
               child: Column(
                 children: [
                   SvgIconButton(
@@ -1619,7 +1629,7 @@ class _GamePageState extends ConsumerState<GamePage>
           if (kDebugMode)
             Positioned(
               left: 12.w,
-              bottom: 157.h + bottomInset,
+              bottom: actionButtonBottom,
               child: FloatingActionButton(
                 heroTag: 'game_debug',
                 mini: true,


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->
안드로이드 3-button 네비 환경에서 채팅 시트 collapsed 영역이 우측 액션 버튼을 가리던 문제 해결
- 우측 액션 버튼 Positioned.bottom에 MediaQuery.viewPadding.bottom 보정 추가 - 채팅 시트와 동일 inset 기준으로 정렬
- 157.h 매직 넘버 제거 — 채팅 시트 collapsed 고정 높이를 kChatOverlayCollapsedFixedHeight 단일 상수로 추출, ChatOverlay 내부와 game_page 모두 동일 공급원 참조
- 시각 여백은 별도 상수(_kActionButtonChatGap)로 분리해 의미 명시


## ✅ 테스트

- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 시스템 인셋을 반영하여 채팅 오버레이 위의 작업 버튼 및 디버그 버튼의 위치를 개선했습니다.

* **리팩터링**
  * 채팅 오버레이 높이 계산 로직을 간소화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->