### PR TITLE
20260505 #332 크레딧 인원 추가 및 기여도별 색상 차별화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ app.*.map.json
 /.report
 /.release-note
 /.issues
+/.pr
 
 .env
 /env.*

--- a/lib/features/credits/domain/credit_member.dart
+++ b/lib/features/credits/domain/credit_member.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/painting.dart';
 
+import '../../../core/constants/app_colors.dart';
+
 /// 소셜 링크 타입
 ///
 /// 모든 타입은 SVG 에셋을 사용한다. (tree-shake-icons 최적화 충돌 방지)
@@ -166,20 +168,150 @@ const List<CreditMember> creditMembers = [
 
 /// 도움 준 사람 정보
 class CreditHelper {
-  const CreditHelper({required this.name, required this.role});
+  const CreditHelper({
+    required this.name,
+    required this.role,
+    required this.tier,
+    this.participationCount = 1,
+  });
 
   final String name;
   final String role;
+
+  /// 표시 등급 — 색상/굵기를 결정하는 단일 진실(single source of truth).
+  final ContributionTier tier;
+
+  /// 참여 횟수 메타데이터 (현재 표시에는 영향 없음).
+  ///
+  /// 자동 계산이 아니라 데이터 입력 시점에 사람이 명시한다.
+  /// 미래에 통계, 정렬, 툴팁 등에 활용 가능.
+  final int participationCount;
 }
 
-/// 도움 준 사람들 목록
+/// 크레딧 기여도 티어 (5단계)
+///
+/// - tier1~3: QA 참여 횟수 기반 (1회 / 2회 / 3회+) — 데이터 입력 시점에 수동 분류
+/// - tier4~5: 인프라 제공·후원 등 큰 도움 — 수동 지정
+///
+/// 자동 카운트 로직을 두지 않는다. 4·5단계는 어차피 수동이라 두 로직이 섞이면 복잡.
+enum ContributionTier { tier1, tier2, tier3, tier4, tier5 }
+
+/// 티어별 텍스트 색상 (`SocialType.tintColor` 패턴과 동일하게 enum extension)
+///
+/// 검은 배경(`AppColors.black`) 기준 perceived brightness가 단조 증가하도록 매핑.
+/// (134 → 171 → 196 → 220 → 227)
+extension ContributionTierColor on ContributionTier {
+  Color get color => switch (this) {
+    ContributionTier.tier1 => AppColors.black500, // #76899E (134) — 회색
+    ContributionTier.tier2 => AppColors.green, // #38F55B (171) — 비비드 초록
+    ContributionTier.tier3 => AppColors.green800, // #7AF391 (196) — 밝은 초록
+    ContributionTier.tier4 => AppColors.yellow, // #F5EF38 (220) — 선명 노랑
+    ContributionTier.tier5 => AppColors.yellow900, // #F7F260 (227) — 가장 밝은 노랑
+  };
+}
+
+/// 도움 준 사람들 목록 (unique union — 중복 이름은 한 번만, 횟수는 메타로 보존)
+///
+/// 마키 노출 우선순위를 위해 **티어 높은 순**으로 정렬 (tier4 → tier2 → tier1).
+/// 같은 티어 안에서는 명단 입력 순서를 유지한다.
 const List<CreditHelper> creditHelpers = [
-  CreditHelper(name: '안금서', role: 'QA'),
-  CreditHelper(name: '남해윤', role: 'QA'),
-  CreditHelper(name: '손건우', role: 'QA'),
-  CreditHelper(name: '송혜정', role: 'QA'),
-  CreditHelper(name: '신혜빈', role: 'QA'),
-  CreditHelper(name: '이진', role: 'QA'),
-  CreditHelper(name: '정창우', role: 'QA'),
-  CreditHelper(name: '허석준', role: 'QA'),
+  // 인프라 제공 (tier4) — 가장 높은 강조
+  CreditHelper(
+    name: '신지훈',
+    role: '인프라 제공',
+    tier: ContributionTier.tier4,
+    participationCount: 1,
+  ),
+  // 2회 참여 QA (tier2)
+  CreditHelper(
+    name: '남해윤',
+    role: 'QA',
+    tier: ContributionTier.tier2,
+    participationCount: 2,
+  ),
+  CreditHelper(
+    name: '송혜정',
+    role: 'QA',
+    tier: ContributionTier.tier2,
+    participationCount: 2,
+  ),
+  CreditHelper(
+    name: '이진',
+    role: 'QA',
+    tier: ContributionTier.tier2,
+    participationCount: 2,
+  ),
+  // 1회 참여 QA (tier1) — 12명
+  CreditHelper(
+    name: '안금서',
+    role: 'QA',
+    tier: ContributionTier.tier1,
+    participationCount: 1,
+  ),
+  CreditHelper(
+    name: '손건우',
+    role: 'QA',
+    tier: ContributionTier.tier1,
+    participationCount: 1,
+  ),
+  CreditHelper(
+    name: '신혜빈',
+    role: 'QA',
+    tier: ContributionTier.tier1,
+    participationCount: 1,
+  ),
+  CreditHelper(
+    name: '정창우',
+    role: 'QA',
+    tier: ContributionTier.tier1,
+    participationCount: 1,
+  ),
+  CreditHelper(
+    name: '허석준',
+    role: 'QA',
+    tier: ContributionTier.tier1,
+    participationCount: 1,
+  ),
+  CreditHelper(
+    name: '서현진',
+    role: 'QA',
+    tier: ContributionTier.tier1,
+    participationCount: 1,
+  ),
+  CreditHelper(
+    name: '오동현',
+    role: 'QA',
+    tier: ContributionTier.tier1,
+    participationCount: 1,
+  ),
+  CreditHelper(
+    name: '최승훈',
+    role: 'QA',
+    tier: ContributionTier.tier1,
+    participationCount: 1,
+  ),
+  CreditHelper(
+    name: '김민욱',
+    role: 'QA',
+    tier: ContributionTier.tier1,
+    participationCount: 1,
+  ),
+  CreditHelper(
+    name: '정명준',
+    role: 'QA',
+    tier: ContributionTier.tier1,
+    participationCount: 1,
+  ),
+  CreditHelper(
+    name: '강대현',
+    role: 'QA',
+    tier: ContributionTier.tier1,
+    participationCount: 1,
+  ),
+  CreditHelper(
+    name: '심 혁',
+    role: 'QA',
+    tier: ContributionTier.tier1,
+    participationCount: 1,
+  ),
 ];

--- a/lib/features/credits/presentation/pages/credits_page.dart
+++ b/lib/features/credits/presentation/pages/credits_page.dart
@@ -89,21 +89,27 @@ class CreditsPage extends StatelessWidget {
                   SizedBox(height: AppSpacing.vertical12),
                   MarqueeWidget(
                     child: Row(
-                      children: creditHelpers
-                          .map(
-                            (helper) => Padding(
-                              padding: EdgeInsets.symmetric(
-                                horizontal: AppSpacing.horizontal16,
-                              ),
-                              child: Text(
-                                '${helper.name} (${helper.role})',
-                                style: AppTextStyles.paragraph_14.copyWith(
-                                  color: AppColors.black500,
-                                ),
-                              ),
+                      children: [
+                        // 첫 항목이 화면에 진입하기 전 시각적 휴지 — 화면 너비만큼
+                        // spacer를 두어 첫 텍스트(tier4)가 화면 오른쪽 밖에서
+                        // 들어오도록 하고, 한 사이클 사이에도 호흡을 만든다.
+                        SizedBox(width: 0.7.sw),
+                        ...creditHelpers.map(
+                          (helper) => Padding(
+                            padding: EdgeInsets.symmetric(
+                              horizontal: AppSpacing.horizontal16,
                             ),
-                          )
-                          .toList(),
+                            child: Text(
+                              '${helper.name} (${helper.role})',
+                              style:
+                                  (helper.tier == ContributionTier.tier5
+                                          ? AppTextStyles.paragraph14Semibold
+                                          : AppTextStyles.paragraph_14)
+                                      .copyWith(color: helper.tier.color),
+                            ),
+                          ),
+                        ),
+                      ],
                     ),
                   ),
                 ],


### PR DESCRIPTION
## ✨ 변경 사항
--- 
# feat : 크레딧 인원 보강 및 기여도별 색상 차별화 #332

## Summary

크레딧 페이지 하단 Special Thanks 섹션에 5단계 기여도 티어 시스템 도입. helpers를 8명에서 16명으로 보강하고, 참여 횟수·기여 종류에 따라 텍스트 색상을 차별화한다. 마키 첫 등장 가독성도 함께 개선.

## Changes

- `credit_member.dart`: `ContributionTier` enum (tier1~tier5) + `ContributionTierColor` extension getter 추가
- `credit_member.dart`: `CreditHelper`에 `tier` (required), `participationCount` (default 1) 필드 추가
- `credit_member.dart`: `creditHelpers` 8명 → 16명 (인프라 제공 1명 포함), tier 높은 순(tier4 → tier2 → tier1)으로 정렬
- `credits_page.dart`: 마키 텍스트 스타일을 `helper.tier.color` 기반으로 분기, tier5에 한해 `paragraph14Semibold`로 굵기 강조
- `credits_page.dart`: 마키 Row의 첫 child로 `SizedBox(width: 0.7.sw)` leading spacer 추가

## Behavior Change

색상 매핑 (검은 배경 대비 perceived brightness 단조 증가):

| tier | 색상 | brightness | 부여 기준 | 현재 인원 |
|---|---|---|---|---|
| tier1 | `black500` (회색) | 134 | 1회 참여 | 12명 |
| tier2 | `green` (비비드 초록) | 171 | 2회 참여 | 3명 (송혜정·남해윤·이진) |
| tier3 | `green800` (밝은 초록) | 196 | 3회+ 참여 | 0명 (빈 슬롯) |
| tier4 | `yellow` (선명 노랑) | 220 | 인프라/지원 | 1명 (신지훈) |
| tier5 | `yellow900` (가장 밝은 노랑) | 227 | 후원/최고 공로 | 0명 (빈 슬롯) |

| 항목 | Before | After |
|---|---|---|
| helpers 명단 | 8명 (모두 QA, 동일 회색) | 16명 (티어별 색상 차별화) |
| 마키 첫 텍스트 | 화면 왼쪽 끝에서 즉시 사라짐 | 화면 오른쪽 밖에서 진입 |
| tier4·5 강조 | — | tier5만 `paragraph14Semibold` 굵기 추가 |

```dart
// Before
style: AppTextStyles.paragraph_14.copyWith(
  color: AppColors.black500,
),

// After
style: (helper.tier == ContributionTier.tier5
        ? AppTextStyles.paragraph14Semibold
        : AppTextStyles.paragraph_14)
    .copyWith(color: helper.tier.color),
```

## Test Plan

- [x] `flutter analyze lib/features/credits/` 통과 (`No issues found!`)
- [ ] 설정 → 앱 버전 5번 탭 → 크레딧 페이지 진입
- [ ] Special Thanks 마키에서 tier별 색상 그라데이션 확인
  - 신지훈 (인프라 제공): 노랑 (tier4)
  - 송혜정·남해윤·이진: 비비드 초록 (tier2)
  - 일반 QA 12명: 회색 (tier1)
- [ ] 첫 텍스트(신지훈)가 화면 오른쪽 밖에서 흘러 들어오는지 확인
- [ ] 마키 무한 루프 정상 동작 (끊김·뚝뚝거림 없음)

## Notes

- 상단 멤버 카드(`creditMembers`) 및 `CreditMember`/`SocialType`/`SocialLink` 클래스는 변경 없음
- tier3, tier5는 미래 확장용 빈 슬롯 — 추후 별도 PR
- 자동 카운트 로직은 도입하지 않음 (tier4·5는 어차피 수동 지정이라 두 로직 섞이면 복잡 — 데이터 입력 시 사람이 명시)
- 자동화 테스트는 작성하지 않음 — 변경이 데이터 상수 + enum 매핑(`const switch` exhaustive) + UI 1줄 분기라 컴파일러+시각 검증으로 갈음
- 디자인 결정 근거: `docs/superpowers/specs/2026-05-05-credits-tier-design.md`
- 구현 보고서: `.report/20260505_#332_크레딧_인원_추가_및_기여도별_색상_차별화.md`

Closes #332



## ✅ 테스트
---

- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 크레딧 지원자에게 기여도 등급 시스템(5단계)을 추가하여 참여도에 따라 분류 가능

* **스타일**
  * "특별한 감사" 섹션에 등급별 시각적 스타일 적용으로 표시 개선

* **Chores**
  * CocoaPods 디렉토리를 빌드 제외 목록에 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->