### PR TITLE
docs : 크레딧 인프라 제공 라벨을 영문 표기 Infra Provision으로 변경 #334

### DIFF
--- a/lib/features/credits/domain/credit_member.dart
+++ b/lib/features/credits/domain/credit_member.dart
@@ -218,7 +218,7 @@ const List<CreditHelper> creditHelpers = [
   // 인프라 제공 (tier4) — 가장 높은 강조
   CreditHelper(
     name: '신지훈',
-    role: '인프라 제공',
+    role: 'Infra Provision',
     tier: ContributionTier.tier4,
     participationCount: 1,
   ),


### PR DESCRIPTION
## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->
- 크레딧 페이지 "인프라 제공" 라벨을 영문 표기 "Infra Provision"으로 변경. 

- Closes #334


## ✅ 테스트
---

- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 크레딧 섹션의 기여자 역할 설명을 영어로 업데이트했습니다. 국제 사용자의 접근성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->