### PR TITLE
fix : 서버 시각 timezone 누락 방어로 재접속 시 경찰 대기 시간 오표시 해결 #339

### DIFF
--- a/lib/core/utils/iso_timestamp_parser.dart
+++ b/lib/core/utils/iso_timestamp_parser.dart
@@ -4,13 +4,13 @@
 /// - **nanosecond 절단**: Dart [DateTime]은 microsecond(소수점 6자리)까지만
 ///   지원하므로 7자리 이상은 6자리로 자른다.
 ///   (예: `"...:38.731399999"` → `"...:38.731399"`)
-/// - **timezone 누락 시 UTC 가정**: ISO 문자열 끝에 `Z` 또는 `±HH:MM` suffix가
-///   없으면 백엔드가 UTC 의도로 보냈다고 보고 `Z`를 강제 부여한다.
-///   Dart 기본 동작은 단말 local timezone으로 해석하므로, 백엔드 UTC와
-///   단말 KST 사이에 9시간 오프셋이 발생하는 버그를 방지하기 위함이다.
-///   (이슈 #339 — `GET /api/games/{id}` 응답의 `gameStartTime`이 timezone
-///   suffix 없이 내려와 재접속 시 경찰 대기 시간이 약 530분으로 표시되던 문제)
-/// - **반환은 local로 변환**: `DateTime.now()` 같은 local 기준값과 비교할 때
+/// - **timezone 누락 시 KST(Asia/Seoul) 가정**: 백엔드 `ClockConfig`가
+///   `Clock.system(ZoneId.of("Asia/Seoul"))`로 설정되어 `LocalDateTime`을
+///   timezone suffix 없이 직렬화하므로, 누락된 입력은 `+09:00`을 강제 부여해
+///   KST로 해석한다. 단말 timezone에 의존하지 않고 일관된 시각 계산을 보장한다.
+///   (이슈 #339 — Android 에뮬레이터처럼 단말 timezone이 KST가 아닌 환경에서
+///   재접속 시 경찰 대기 시간이 약 530분으로 표시되던 문제)
+/// - **단말 local로 변환**: `DateTime.now()` 같은 local 기준값과 비교할 때
 ///   사람이 읽는 시각 표현이 의도대로 동작하도록 `.toLocal()`을 적용한다.
 ///
 /// 빈 문자열·`null`·파싱 실패 시 `null` 반환.
@@ -24,7 +24,9 @@ class IsoTimestampParser {
   static DateTime? parse(String? raw) {
     if (raw == null || raw.isEmpty) return null;
     final trimmed = raw.replaceFirstMapped(_nanoTrimRegex, (m) => m.group(1)!);
-    final withTz = _timezoneRegex.hasMatch(trimmed) ? trimmed : '${trimmed}Z';
+    final withTz = _timezoneRegex.hasMatch(trimmed)
+        ? trimmed
+        : '$trimmed+09:00';
     return DateTime.tryParse(withTz)?.toLocal();
   }
 }

--- a/lib/core/utils/iso_timestamp_parser.dart
+++ b/lib/core/utils/iso_timestamp_parser.dart
@@ -1,0 +1,30 @@
+/// 서버 응답의 ISO-8601 타임스탬프를 안전하게 [DateTime]으로 파싱한다.
+///
+/// 처리 정책:
+/// - **nanosecond 절단**: Dart [DateTime]은 microsecond(소수점 6자리)까지만
+///   지원하므로 7자리 이상은 6자리로 자른다.
+///   (예: `"...:38.731399999"` → `"...:38.731399"`)
+/// - **timezone 누락 시 UTC 가정**: ISO 문자열 끝에 `Z` 또는 `±HH:MM` suffix가
+///   없으면 백엔드가 UTC 의도로 보냈다고 보고 `Z`를 강제 부여한다.
+///   Dart 기본 동작은 단말 local timezone으로 해석하므로, 백엔드 UTC와
+///   단말 KST 사이에 9시간 오프셋이 발생하는 버그를 방지하기 위함이다.
+///   (이슈 #339 — `GET /api/games/{id}` 응답의 `gameStartTime`이 timezone
+///   suffix 없이 내려와 재접속 시 경찰 대기 시간이 약 530분으로 표시되던 문제)
+/// - **반환은 local로 변환**: `DateTime.now()` 같은 local 기준값과 비교할 때
+///   사람이 읽는 시각 표현이 의도대로 동작하도록 `.toLocal()`을 적용한다.
+///
+/// 빈 문자열·`null`·파싱 실패 시 `null` 반환.
+class IsoTimestampParser {
+  IsoTimestampParser._();
+
+  static final _nanoTrimRegex = RegExp(r'(\.\d{1,6})\d*');
+  static final _timezoneRegex = RegExp(r'(Z|[+-]\d{2}:?\d{2})$');
+
+  /// ISO-8601 문자열을 단말 local [DateTime]으로 파싱한다.
+  static DateTime? parse(String? raw) {
+    if (raw == null || raw.isEmpty) return null;
+    final trimmed = raw.replaceFirstMapped(_nanoTrimRegex, (m) => m.group(1)!);
+    final withTz = _timezoneRegex.hasMatch(trimmed) ? trimmed : '${trimmed}Z';
+    return DateTime.tryParse(withTz)?.toLocal();
+  }
+}

--- a/lib/features/game/presentation/pages/game_page.dart
+++ b/lib/features/game/presentation/pages/game_page.dart
@@ -11,6 +11,7 @@ import 'package:go_router/go_router.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 import '../../../../core/constants/app_colors.dart';
+import '../../../../core/utils/iso_timestamp_parser.dart';
 import '../../../../core/services/tutorial/tutorial_keys.dart';
 import '../../../../core/services/tutorial/tutorial_service.dart';
 import '../../../../core/tutorial/app_tutorial_style.dart';
@@ -384,9 +385,7 @@ class _GamePageState extends ConsumerState<GamePage>
     final participantStartTimeStr = participantInfo?.gameStartTime;
     final effectiveStartTime =
         gameEvent.gameStartTime ??
-        (participantStartTimeStr != null
-            ? DateTime.tryParse(participantStartTimeStr)
-            : null);
+        IsoTimestampParser.parse(participantStartTimeStr);
 
     if (effectiveStartTime == null) return;
 
@@ -429,7 +428,7 @@ class _GamePageState extends ConsumerState<GamePage>
     final waitMinutes = info?.policeWaitMinutes;
     if (startTimeStr == null || waitMinutes == null || waitMinutes <= 0) return;
 
-    final startTime = DateTime.tryParse(startTimeStr);
+    final startTime = IsoTimestampParser.parse(startTimeStr);
     if (startTime == null) return;
 
     final waitEndTime = startTime.add(Duration(minutes: waitMinutes));
@@ -512,9 +511,7 @@ class _GamePageState extends ConsumerState<GamePage>
     if (waitMinutes == null || waitMinutes <= 0) return null;
 
     final startTimeStr = info?.gameStartTime;
-    final startTime = startTimeStr != null
-        ? DateTime.tryParse(startTimeStr)
-        : null;
+    final startTime = IsoTimestampParser.parse(startTimeStr);
     // 더미 모드 시 _dummyStartTime 사용
     final effectiveStartTime = _dummyStartTime ?? startTime;
     if (effectiveStartTime == null) return null;
@@ -561,7 +558,7 @@ class _GamePageState extends ConsumerState<GamePage>
     final participantInfo = ref.read(gameParticipantNotifierProvider);
     final startTimeStr = participantInfo?.gameStartTime;
     if (startTimeStr != null) {
-      final startTime = DateTime.tryParse(startTimeStr);
+      final startTime = IsoTimestampParser.parse(startTimeStr);
       if (startTime != null &&
           DateTime.now().difference(startTime).inSeconds > 20) {
         return;
@@ -1769,9 +1766,9 @@ class _GamePageState extends ConsumerState<GamePage>
       gameEventNotifierProvider.select((s) => s.gameStartTime),
     );
     final participantInfo = ref.watch(gameParticipantNotifierProvider);
-    final participantStartTime = participantInfo?.gameStartTime != null
-        ? DateTime.tryParse(participantInfo!.gameStartTime!)
-        : null;
+    final participantStartTime = IsoTimestampParser.parse(
+      participantInfo?.gameStartTime,
+    );
     // 우선순위: 더미 시작 시각 → STOMP START 이벤트 시각 → 대기실 게임 시작 시각
     final gameStartTime =
         _dummyStartTime ?? stompGameStartTime ?? participantStartTime;

--- a/lib/features/game/presentation/providers/game_event_provider.dart
+++ b/lib/features/game/presentation/providers/game_event_provider.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../../core/constants/api_endpoints.dart';
+import '../../../../core/utils/iso_timestamp_parser.dart';
 import '../../../../core/services/vibration_service.dart';
 import '../../../../core/services/lifecycle/app_lifecycle_service.dart';
 import '../../../../core/services/background/background_service_provider.dart';
@@ -118,8 +119,7 @@ class GameEventState {
 
     final gameStartTimeStr = participantInfo?.gameStartTime;
     final effectiveStartTime =
-        gameStartTime ??
-        (gameStartTimeStr != null ? DateTime.tryParse(gameStartTimeStr) : null);
+        gameStartTime ?? IsoTimestampParser.parse(gameStartTimeStr);
 
     return policeWaitMinutes != null &&
         effectiveStartTime != null &&
@@ -583,7 +583,7 @@ class GameEventNotifier extends _$GameEventNotifier {
         _handleStart(event.data);
       case GameEventType.policeMoveStart:
         final moveStartTime =
-            _parseTimestamp(event.timestamp) ?? DateTime.now();
+            IsoTimestampParser.parse(event.timestamp) ?? DateTime.now();
         state = state.copyWith(
           isPoliceMoving: true,
           policeMoveStartTime: moveStartTime,
@@ -600,7 +600,7 @@ class GameEventNotifier extends _$GameEventNotifier {
 
   void _handleStart(Map<String, dynamic> data) {
     final startTimeStr = data['startTime'] as String?;
-    final startTime = _parseTimestamp(startTimeStr);
+    final startTime = IsoTimestampParser.parse(startTimeStr);
     state = state.copyWith(
       gameStartTime: startTime ?? DateTime.now(),
       bannerMessage: GameEventMessages.gameStartGo,
@@ -654,7 +654,7 @@ class GameEventNotifier extends _$GameEventNotifier {
       }
     }
 
-    final revealTime = _parseTimestamp(timestamp) ?? DateTime.now();
+    final revealTime = IsoTimestampParser.parse(timestamp) ?? DateTime.now();
     state = state.copyWith(
       lastLocationRevealTime: revealTime,
       bannerMessage: GameEventMessages.locationReveal,
@@ -748,19 +748,6 @@ class GameEventNotifier extends _$GameEventNotifier {
   }
 
   // ============================================================
-  // 유틸리티
-  // ============================================================
-
-  static DateTime? _parseTimestamp(String? raw) {
-    if (raw == null) return null;
-    final normalized = raw.replaceFirstMapped(
-      RegExp(r'(\.\d{1,6})\d*'),
-      (m) => m.group(1)!,
-    );
-    return DateTime.tryParse(normalized);
-  }
-
-  // ============================================================
   // 스트림 설정 및 재연결 정책
   // ============================================================
 
@@ -820,7 +807,7 @@ class GameEventNotifier extends _$GameEventNotifier {
       debugPrint('[GameEventNotifier] ⏭️ 발자국 복구 skip (게임 설정 미로드)');
       return;
     }
-    final startTime = DateTime.tryParse(gameStartTimeStr);
+    final startTime = IsoTimestampParser.parse(gameStartTimeStr);
     if (startTime == null) {
       debugPrint('[GameEventNotifier] ⏭️ 발자국 복구 skip (startTime 파싱 실패)');
       return;

--- a/test/core/utils/iso_timestamp_parser_test.dart
+++ b/test/core/utils/iso_timestamp_parser_test.dart
@@ -3,15 +3,18 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('IsoTimestampParser', () {
-    test('returns_utc_assumed_datetime_when_timezone_suffix_missing', () {
-      // 이슈 #339 회귀 방지: timezone 누락 시 단말 local로 해석되면
-      // 백엔드 UTC와 9시간 오프셋이 발생함.
+    test('returns_kst_assumed_datetime_when_timezone_suffix_missing', () {
+      // 이슈 #339 회귀 방지: 백엔드 ClockConfig가 Asia/Seoul 기준이므로
+      // timezone suffix가 누락된 응답은 KST 의도로 해석해야 함.
+      // (단말 timezone이 KST가 아닌 환경에서 9시간 오프셋 방지)
       final result = IsoTimestampParser.parse('2026-05-11T14:53:38');
 
       expect(
         result?.toUtc(),
-        DateTime.utc(2026, 5, 11, 14, 53, 38),
-        reason: 'timezone suffix가 없으면 UTC로 가정해야 함',
+        DateTime.utc(2026, 5, 11, 5, 53, 38),
+        reason:
+            'timezone suffix가 없으면 KST로 가정 → '
+            'KST 14:53:38 = UTC 05:53:38',
       );
     });
 
@@ -35,12 +38,13 @@ void main() {
       expect(result?.toUtc().microsecond, 731399);
     });
 
-    test('returns_same_instant_for_naive_and_z_suffixed_inputs', () {
-      // 백엔드의 timezone 누락 응답과 명시적 UTC 응답이 같은 시각으로 해석되어야 함.
+    test('returns_same_instant_for_naive_and_kst_suffixed_inputs', () {
+      // 백엔드의 timezone 누락 응답(KST 의도)과 명시적 KST 응답이
+      // 같은 시각으로 해석되어야 함.
       final naive = IsoTimestampParser.parse('2026-05-11T14:53:38');
-      final withZ = IsoTimestampParser.parse('2026-05-11T14:53:38Z');
+      final withKst = IsoTimestampParser.parse('2026-05-11T14:53:38+09:00');
 
-      expect(naive, withZ);
+      expect(naive, withKst);
     });
 
     test('returns_null_when_input_is_null', () {

--- a/test/core/utils/iso_timestamp_parser_test.dart
+++ b/test/core/utils/iso_timestamp_parser_test.dart
@@ -1,0 +1,58 @@
+import 'package:cops_and_robbers/core/utils/iso_timestamp_parser.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('IsoTimestampParser', () {
+    test('returns_utc_assumed_datetime_when_timezone_suffix_missing', () {
+      // 이슈 #339 회귀 방지: timezone 누락 시 단말 local로 해석되면
+      // 백엔드 UTC와 9시간 오프셋이 발생함.
+      final result = IsoTimestampParser.parse('2026-05-11T14:53:38');
+
+      expect(
+        result?.toUtc(),
+        DateTime.utc(2026, 5, 11, 14, 53, 38),
+        reason: 'timezone suffix가 없으면 UTC로 가정해야 함',
+      );
+    });
+
+    test('preserves_offset_when_explicit_timezone_provided', () {
+      // KST 23:53:38 = UTC 14:53:38
+      final result = IsoTimestampParser.parse('2026-05-11T23:53:38+09:00');
+
+      expect(result?.toUtc(), DateTime.utc(2026, 5, 11, 14, 53, 38));
+    });
+
+    test('parses_as_utc_when_z_suffix_present', () {
+      final result = IsoTimestampParser.parse('2026-05-11T14:53:38Z');
+
+      expect(result?.toUtc(), DateTime.utc(2026, 5, 11, 14, 53, 38));
+    });
+
+    test('truncates_subsecond_to_microsecond_precision', () {
+      // Dart DateTime은 microsecond(6자리)까지만 지원.
+      final result = IsoTimestampParser.parse('2026-05-11T14:53:38.731399999Z');
+
+      expect(result?.toUtc().microsecond, 731399);
+    });
+
+    test('returns_same_instant_for_naive_and_z_suffixed_inputs', () {
+      // 백엔드의 timezone 누락 응답과 명시적 UTC 응답이 같은 시각으로 해석되어야 함.
+      final naive = IsoTimestampParser.parse('2026-05-11T14:53:38');
+      final withZ = IsoTimestampParser.parse('2026-05-11T14:53:38Z');
+
+      expect(naive, withZ);
+    });
+
+    test('returns_null_when_input_is_null', () {
+      expect(IsoTimestampParser.parse(null), isNull);
+    });
+
+    test('returns_null_when_input_is_empty', () {
+      expect(IsoTimestampParser.parse(''), isNull);
+    });
+
+    test('returns_null_when_input_is_invalid_format', () {
+      expect(IsoTimestampParser.parse('not-a-date'), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->
서버 응답 ISO 타임스탬프에 timezone suffix가 누락될 때 단말 timezone(특히 Android 에뮬레이터의 UTC default)에 의존하지 않도록 **KST(Asia/Seoul) 가정**으로 일관 해석.

**증상**: 게임 진행 중 재접속 시 경찰 대기 카운트다운이 약 530분(≈9시간)으로 표시되던 버그 (단말 timezone이 KST가 아닌 경우)

- `IsoTimestampParser.parse()` 공용 유틸 신규
  - timezone 누락 시 `+09:00` 강제 부여
  - nanosecond → microsecond 절단
  - 단말 local timezone 변환
- `game_page.dart` / `game_event_provider.dart`의 `DateTime.tryParse` 호출 10곳 → 새 유틸로 통일
- 기존 `_parseTimestamp` private 헬퍼 제거 (역할 흡수)
- 단위 테스트 8 케이스 추가
  - naive(KST) / +09:00 / Z / nano 절단 / naive==KST / null / empty / invalid format

> 백엔드 측에도 별도 이슈로 `gameStartTime` 응답 timezone suffix(`+09:00`) 부여 요청 완료. 본 변경은 hotfix 겸 향후 회귀 방어용.

- Closes #339

## ✅ 테스트

- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 게임 이벤트 및 타이머와 관련된 서버 타임스탐프 파싱 안정성 개선 (다양한 ISO-8601 형식 자동 지원, 소수점 자리수 정규화, 누락된 타임존 자동 처리)

* **테스트**
  * 타임스탐프 파서 테스트 커버리지 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cops-and-robbers/cops-and-robbers-FE/pull/340)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->