### PR TITLE
20260507 #336 별도 튜토리얼 페이지 신설 및 기존 코치마크 시스템 대체

### DIFF
--- a/.claude/commands/rp.md
+++ b/.claude/commands/rp.md
@@ -1,0 +1,129 @@
+# RP Mode - Report + PR Description 병렬 생성
+
+`/report`와 `/pr-description`을 **병렬로 동시 실행**하여 한 번에 두 산출물을 생성한다.
+
+- `.report/{YYYYMMDD}_{ISSUE#}_{설명}.md` — 구현 보고서
+- `.pr/{YYYYMMDD}_{ISSUE#}_{설명}.md` — PR 본문
+
+## 핵심 원칙
+
+- **반드시 단일 메시지에서 두 Agent 호출을 동시에 디스패치** (병렬 tool use)
+- Git 명령은 디스패치 전 1회만 실행 → 결과를 양쪽 Agent에 전달 (중복 호출 방지)
+- ARGUMENTS로 들어온 이슈 본문/추가 컨텍스트가 있으면 양쪽 Agent 프롬프트에 그대로 포함
+- 두 Agent는 서로의 결과를 기다리지 않고 독립 작성 (동일 git 컨텍스트 기반)
+- 두 작업 완료 후 저장 경로만 짧게 요약하고 종료
+
+## 실행 절차
+
+### 1단계: 컨텍스트 수집 (디스패치 전 1회)
+
+다음 명령을 병렬로 실행:
+
+```bash
+git status
+git log main..HEAD --oneline
+git diff main --name-only
+```
+
+브랜치명에서 `#숫자` 추출 → 이슈 번호 확정. 없으면 ARGUMENTS에서 추출.
+
+### 2단계: 두 Agent 병렬 디스패치 (필수)
+
+**한 메시지에 Agent 호출 2개**를 함께 보냄. 절대 순차 실행하지 않음.
+
+#### Agent A — 보고서 생성
+
+- `subagent_type`: `general-purpose`
+- `description`: "Generate implementation report"
+- `prompt`: 아래 템플릿
+- 반드시 Skill 도구로 `report` 스킬 호출 또는 `.claude/commands/report.md`의 지침을 그대로 따라 `.report/`에 파일 생성
+
+```
+프로젝트: /Users/luca/workspace/greedy/quickness-game
+브랜치: {브랜치명}
+이슈 번호: #{N}
+
+# Git 컨텍스트 (이미 수집됨 — 추가 git 명령 실행 금지)
+## git status
+{git status 결과}
+
+## git log main..HEAD
+{커밋 목록}
+
+## 변경 파일 목록
+{파일 목록}
+
+# 이슈/추가 컨텍스트 (사용자 ARGUMENTS)
+{ARGUMENTS}
+
+# 작업
+`.claude/commands/report.md`에 정의된 Report Mode 지침을 그대로 따라
+`.report/{YYYYMMDD}_#{N}_{한글설명}.md` 파일을 생성하라.
+
+- 위 git 컨텍스트만 사용. 추가 git 명령 실행 금지.
+- 변경 파일을 직접 Read해서 분석.
+- 작성자/작성일/AI 관련 표현 금지.
+- 시크릿은 마스킹.
+- 완료 시 저장된 파일 경로 한 줄로 보고.
+```
+
+#### Agent B — PR 본문 생성
+
+- `subagent_type`: `general-purpose`
+- `description`: "Generate PR description"
+- `prompt`: 아래 템플릿
+
+```
+프로젝트: /Users/luca/workspace/greedy/quickness-game
+브랜치: {브랜치명}
+이슈 번호: #{N}
+
+# Git 컨텍스트 (이미 수집됨 — 추가 git 명령 실행 금지)
+## git status
+{git status 결과}
+
+## git log main..HEAD
+{커밋 목록}
+
+## 변경 파일 목록
+{파일 목록}
+
+# 이슈/추가 컨텍스트 (사용자 ARGUMENTS)
+{ARGUMENTS}
+
+# 기존 보고서 (있으면 우선 참조)
+.report/ 디렉토리에 같은 이슈/날짜 매칭 보고서가 있으면 1차 소스로 활용.
+없거나 본 세션에서 막 생성 중이라면 git 컨텍스트 + 변경 파일 직접 분석으로 작성.
+
+# 작업
+`.claude/commands/pr-description.md`에 정의된 PR Description Mode 지침을 따라
+`.pr/{YYYYMMDD}_#{N}_{한글설명}.md` 파일을 생성하라.
+
+- Summary / Changes / Behavior Change / Test Plan / Notes / Closes #N 구조.
+- AI/작성자 메타 정보 금지. 시크릿 마스킹.
+- 마지막 줄에 `Closes #{N}` 포함.
+- 완료 시 저장된 파일 경로 + PR 제목 제안 한 줄로 보고.
+```
+
+### 3단계: 결과 요약
+
+두 Agent 완료 후 다음 형식으로 한 번만 출력:
+
+```
+✅ 보고서: .report/{경로}.md
+✅ PR 본문: .pr/{경로}.md
+
+PR 생성:
+gh pr create --title "{type} : {제목} #{N}" --body-file ".pr/{경로}.md"
+```
+
+## 절대 금지 사항
+
+- 두 Agent를 순차 호출하지 말 것 (반드시 한 메시지에 병렬)
+- 디스패치 전 git 명령 외에 본 커맨드가 추가 파일 분석을 하지 말 것 (Agent에게 위임)
+- AI/작성자 메타 정보 삽입 금지
+- 두 산출물 내용 차이를 임의로 줄이려고 하지 말 것 — 보고서는 "무엇을 했나", PR 본문은 "리뷰어용 요약"으로 역할이 다름
+
+## 출력 후
+
+저장 경로 2개 + `gh pr create` 안내 한 줄 출력 후 종료. 추가 질문 없음.

--- a/docs/superpowers/plans/2026-05-11-in-game-tutorial-entry-point.md
+++ b/docs/superpowers/plans/2026-05-11-in-game-tutorial-entry-point.md
@@ -1,0 +1,303 @@
+# 인게임 튜토리얼 자동 진입점 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 대기방 코치마크가 끝나는 시점에 인게임 튜토리얼 페이지를 안내하는 1버튼 다이얼로그를 추가한다. 신규 사용자가 게임 시작 전에 인게임 화면 동작을 학습할 수 있도록 강제 노출하되, 한 번 노출되면 다시 뜨지 않는다.
+
+**Architecture:** `WaitingRoomPage`의 기존 코치마크 `onFinish` 콜백을 확장한다. `SharedPreferences` 키 1개(`tutorial_in_game_prompt`)로 1회 노출을 보장하고, `AppDialog.show()` 1버튼 모드(`barrierDismissible: false`, "보러 가기")로 다이얼로그를 띄운 뒤 확인 시 `context.push('/tutorial/in-game')`로 이동한다. 인게임 튜토리얼 페이지의 완료 다이얼로그는 이미 caller-agnostic("튜토리얼 끝내기" → `context.pop()`)이라 자동으로 대기방으로 복귀한다.
+
+**Tech Stack:** Flutter, SharedPreferences, go_router, 기존 `TutorialService` / `AppDialog`.
+
+**Spec:** [docs/superpowers/specs/2026-05-11-in-game-tutorial-entry-point-design.md](../specs/2026-05-11-in-game-tutorial-entry-point-design.md)
+
+---
+
+## File Structure
+
+| 파일 | 책임 |
+|---|---|
+| `lib/core/services/tutorial/tutorial_keys.dart` (수정) | `inGamePrompt` 상수 + `all` 리스트 갱신 |
+| `lib/features/session/presentation/pages/waiting_room_page.dart` (수정) | 기존 코치마크 `onFinish` 콜백 → 비동기 + `_showInGameTutorialPromptIfNeeded` 호출 / 신규 private 메서드 추가 |
+| `test/core/services/tutorial/tutorial_keys_test.dart` (수정) | 신규 키가 `all` 리스트에 포함되는지 단위 테스트 추가 |
+
+`waiting_room_page.dart` 자체에 대한 위젯 테스트는 추가하지 않는다 — 코치마크 라이브러리의 GlobalKey 마운트 + 다수 Riverpod provider mock이 필요해 비용 대비 가치가 낮다. 다이얼로그 분기 로직은 단순 SharedPreferences 체크 1번 + 1개의 새 메서드이므로 수동 스모크 테스트로 충분히 검증 가능. 키 관리·`all` 포함 여부는 단위 테스트로 보장.
+
+---
+
+## Task 1: SharedPreferences 키 추가 + 단위 테스트
+
+**Files:**
+- Modify: `lib/core/services/tutorial/tutorial_keys.dart`
+- Modify: `test/core/services/tutorial/tutorial_keys_test.dart`
+
+- [ ] **Step 1 (RED): 실패 테스트 추가**
+
+`test/core/services/tutorial/tutorial_keys_test.dart`의 `void main()` 내부에 새 group 추가:
+
+```dart
+  group('TutorialKeys.inGamePrompt', () {
+    test('단일 키 상수 값', () {
+      expect(TutorialKeys.inGamePrompt, 'tutorial_in_game_prompt');
+    });
+
+    test('TutorialKeys.all 에 포함된다', () {
+      expect(TutorialKeys.all, contains(TutorialKeys.inGamePrompt));
+    });
+  });
+```
+
+- [ ] **Step 2: 테스트 실행 — 실패 확인**
+
+```bash
+flutter test test/core/services/tutorial/tutorial_keys_test.dart
+```
+Expected: 새 테스트 2건 FAIL (`The getter 'inGamePrompt' isn't defined`)
+
+- [ ] **Step 3 (GREEN): 키 추가**
+
+`lib/core/services/tutorial/tutorial_keys.dart` 전체 교체:
+
+```dart
+/// 튜토리얼 화면별 SharedPreferences 키 상수
+class TutorialKeys {
+  TutorialKeys._();
+
+  static const home = 'tutorial_home';
+  static const createStep0 = 'tutorial_create_step0';
+  static const setupPlayground = 'tutorial_setup_playground';
+  static const createStep2 = 'tutorial_create_step2';
+
+  // 대기실 튜토리얼: 역할(경찰/도둑) 무관 사용자당 1회만 노출.
+  // 모든 스텝(팀 변경·초대 코드·게임 설정·준비 버튼)이 양 팀에서 동일한
+  // 안내이므로 팀별 분리가 불필요. 1번 스텝 타겟만 "현재 팀의 반대 팀 첫
+  // 빈 슬롯"으로 호출 시점의 team 값으로 결정된다(키와 무관).
+  static const waitingRoom = 'tutorial_waiting_room';
+
+  // 대기방 코치마크 완료 후 인게임 튜토리얼 페이지 안내 다이얼로그를
+  // 1회만 노출하기 위한 키. "튜토리얼 초기화" 시 함께 reset되어 재노출됨.
+  static const inGamePrompt = 'tutorial_in_game_prompt';
+
+  /// 전체 키 목록 (초기화 시 사용)
+  static const all = [
+    home,
+    createStep0,
+    setupPlayground,
+    createStep2,
+    waitingRoom,
+    inGamePrompt,
+  ];
+}
+```
+
+- [ ] **Step 4: 테스트 실행 — 통과 확인**
+
+```bash
+flutter test test/core/services/tutorial/tutorial_keys_test.dart
+```
+Expected: `+4: All tests passed!` (기존 2건 + 신규 2건)
+
+- [ ] **Step 5: analyze**
+
+```bash
+flutter analyze lib/core/services/tutorial/ test/core/services/tutorial/
+```
+Expected: `No issues found!`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/core/services/tutorial/tutorial_keys.dart \
+        test/core/services/tutorial/tutorial_keys_test.dart
+git commit -m "feat : 인게임 튜토리얼 안내 1회 노출용 inGamePrompt 키 추가 #336"
+```
+
+---
+
+## Task 2: 대기방 코치마크 onFinish 확장
+
+**Files:**
+- Modify: `lib/features/session/presentation/pages/waiting_room_page.dart`
+
+이 태스크에서:
+1. 기존 코치마크 `onFinish` 콜백을 비동기로 바꾸고 신규 메서드 호출
+2. `_showInGameTutorialPromptIfNeeded` private 메서드 추가
+3. 기존 cleanup 2줄(`_tutorialController = null` / `_isTutorialShowing = false`)을 그대로 유지
+
+- [ ] **Step 1: 현재 `onFinish` 위치 확인**
+
+```bash
+grep -n "onFinish: ()" lib/features/session/presentation/pages/waiting_room_page.dart
+```
+Expected: 1개 매치 (line 564 부근)
+
+- [ ] **Step 2: onFinish 콜백 교체**
+
+기존 코드(line 561-569 부근):
+
+```dart
+    _tutorialController = AppTutorialStyle.show(
+      context: context,
+      targets: targets,
+      onFinish: () {
+        TutorialService.markCompleted(key);
+        _tutorialController = null;
+        _isTutorialShowing = false;
+      },
+    );
+```
+
+위 코드를 다음으로 교체:
+
+```dart
+    _tutorialController = AppTutorialStyle.show(
+      context: context,
+      targets: targets,
+      onFinish: () async {
+        TutorialService.markCompleted(key);
+        _tutorialController = null;
+        _isTutorialShowing = false;
+        if (!mounted) return;
+        await _showInGameTutorialPromptIfNeeded();
+      },
+    );
+```
+
+변경 포인트:
+- `() {` → `() async {`
+- 기존 3줄 cleanup 그대로 유지
+- 끝에 `if (!mounted) return;` + `await _showInGameTutorialPromptIfNeeded();` 2줄 추가
+
+- [ ] **Step 3: `_showInGameTutorialPromptIfNeeded` 메서드 추가**
+
+`_showTutorialIfNeeded` 메서드 바로 아래(즉 `_showTutorialIfNeeded`의 닫는 `}` 다음 줄)에 다음 메서드를 삽입한다:
+
+```dart
+  /// 대기방 코치마크가 처음 끝난 직후 1회 노출되는 인게임 튜토리얼 안내.
+  ///
+  /// 키가 이미 mark되어 있으면 아무 동작도 하지 않는다.
+  /// 다이얼로그 표시 **전에** mark를 수행해 어떤 이유로 다이얼로그가
+  /// 중단되더라도 영구 재노출을 방지한다.
+  Future<void> _showInGameTutorialPromptIfNeeded() async {
+    final shown = await TutorialService.isCompleted(
+      TutorialKeys.inGamePrompt,
+    );
+    if (shown || !mounted) return;
+
+    await TutorialService.markCompleted(TutorialKeys.inGamePrompt);
+    if (!mounted) return;
+
+    await AppDialog.show<void>(
+      context: context,
+      title: '인게임 화면 미리 보기',
+      message: '게임이 시작되면 어떻게 동작하는지\n한 번 확인하고 시작해볼까요?',
+      confirmText: '보러 가기',
+      barrierDismissible: false,
+      onConfirm: () => context.push('/tutorial/in-game'),
+    );
+  }
+```
+
+- [ ] **Step 4: analyze**
+
+```bash
+flutter analyze lib/features/session/presentation/pages/waiting_room_page.dart
+```
+Expected: `No issues found!`
+
+- [ ] **Step 5: 기존 테스트 영향 없는지 확인**
+
+```bash
+flutter test test/features/session/ test/core/services/tutorial/
+```
+Expected: 기존 테스트 모두 통과 (회귀 없음)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/features/session/presentation/pages/waiting_room_page.dart
+git commit -m "$(cat <<'EOF'
+feat : 대기방 코치마크 완료 시 인게임 튜토리얼 안내 다이얼로그 #336
+
+- onFinish 콜백을 async로 확장, _showInGameTutorialPromptIfNeeded 호출
+- 1버튼 다이얼로그 ('보러 가기'), barrierDismissible: false
+- mark 먼저 수행 후 다이얼로그 표시 — 중단되어도 영구 재노출 방지
+- 기존 cleanup 2줄(_tutorialController, _isTutorialShowing) 유지
+EOF
+)"
+```
+
+---
+
+## Task 3: 수동 검증 체크리스트
+
+자동화 어려운 부분을 수동으로 확인. 시뮬레이터/디바이스에서 진행.
+
+- [ ] **케이스 A — 신규 사용자 정상 흐름**
+
+1. 설정 → "튜토리얼 초기화" 탭 → 확인 → 홈으로 이동
+2. 방 만들기 또는 참여하기 → 대기방 진입
+3. 대기방 코치마크가 자동 표시되는지 확인
+4. 코치마크 마지막 스텝까지 진행
+5. "인게임 화면 미리 보기" 다이얼로그가 자동으로 뜨는지 확인
+6. 다이얼로그 밖 영역 탭 → 닫히지 않아야 함 (`barrierDismissible: false`)
+7. "보러 가기" 탭 → `/tutorial/in-game` 페이지로 이동 확인
+8. 인게임 튜토리얼 3스텝 미션 진행 → "튜토리얼 끝내기" 탭 → 대기방으로 복귀 확인
+
+- [ ] **케이스 B — 이미 본 사용자**
+
+1. 케이스 A 완료 직후, 대기방에서 나가서 다시 진입
+2. 코치마크가 안 뜨는지 확인 (기존 동작)
+3. "인게임 화면 미리 보기" 다이얼로그도 안 뜨는지 확인
+
+- [ ] **케이스 C — 초기화 후 재노출**
+
+1. 설정 → "튜토리얼 초기화" 탭 → 확인
+2. 대기방 재진입 → 코치마크 다시 뜸 확인
+3. 코치마크 완료 → 다이얼로그도 다시 뜸 확인
+
+- [ ] **케이스 D — KICKED 동시 발생**
+
+1. 호스트와 게스트 2명 디바이스 준비
+2. 게스트가 대기방 입장 → 코치마크 진행 중 호스트가 강퇴
+3. 게스트 화면에서 코치마크 중단 + 강퇴 다이얼로그 → 홈으로 이동 확인
+4. (튜토리얼 페이지 전이 후 강퇴 시뮬레이션도 동일하게 확인)
+
+---
+
+## Self-Review
+
+### Spec 커버리지
+
+| Spec 요구사항 | 매핑 태스크 |
+|---|---|
+| `TutorialKeys.inGamePrompt` 추가 + `all` 갱신 | Task 1 |
+| `WaitingRoomPage._showInGameTutorialPromptIfNeeded` 메서드 추가 | Task 2 Step 3 |
+| 기존 코치마크 `onFinish` async + 신규 호출 체인 | Task 2 Step 2 |
+| 기존 cleanup 2줄 유지 | Task 2 Step 2 (명시) |
+| `barrierDismissible: false` + 1버튼 모드 | Task 2 Step 3 |
+| mark 먼저 / 다이얼로그 나중 | Task 2 Step 3 (코드 + 주석) |
+| 위젯 테스트 — 키 단위 테스트로 대체 (스코프 결정 명시) | File Structure 섹션 |
+| 수동 케이스 (A~D) | Task 3 |
+| `flutter analyze` clean | Task 1 Step 5 + Task 2 Step 4 |
+| 단위 테스트 통과 | Task 1 Step 4 + Task 2 Step 5 |
+
+### Placeholder 스캔
+
+- "TBD"·"TODO"·"implement later" 패턴 0건
+- 모든 코드 스니펫이 완전 (직접 붙여넣기 가능)
+- 명령어 + 기대 출력 명시
+
+### 타입 일관성
+
+- `TutorialKeys.inGamePrompt`: `String` 상수 (`'tutorial_in_game_prompt'`)
+- `TutorialKeys.all`: `List<String>`, `inGamePrompt` 추가
+- `_showInGameTutorialPromptIfNeeded`: `Future<void>` 반환, `_CreateRoomTutorialPageState` 아닌 `_WaitingRoomPageState` 내부 메서드
+- `AppDialog.show<void>`: 시그니처는 `context` (required), `title`/`message` (String?), `confirmText` (String 기본 '확인'), `barrierDismissible` (bool 기본 true), `onConfirm` (VoidCallback?). 모든 인자 호출 시 명시.
+- `context.push('/tutorial/in-game')`: 기존 등록된 라우트와 일치 (`app_router.dart`에 등록 확인 완료)
+
+이슈 없음.
+
+---
+
+**작성자**: Claude (writing-plans skill)
+**브랜치**: `20260507_#336_별도_튜토리얼_페이지_신설_및_기존_코치마크_시스템_대체`

--- a/docs/superpowers/specs/2026-05-11-in-game-tutorial-entry-point-design.md
+++ b/docs/superpowers/specs/2026-05-11-in-game-tutorial-entry-point-design.md
@@ -1,0 +1,145 @@
+# 인게임 튜토리얼 자동 진입점 설계
+
+**작성일**: 2026-05-11
+**브랜치**: `20260507_#336_별도_튜토리얼_페이지_신설_및_기존_코치마크_시스템_대체`
+**관련 이슈**: #336
+
+---
+
+## 1. 목표
+
+`/tutorial/in-game` 페이지가 카탈로그·설정 메뉴를 통한 수동 접근만 가능한 상태다. 신규 사용자가 인게임 화면에서 헤매는 일을 막기 위해 **대기방에서 자동으로 안내 다이얼로그를 띄워 한 번만 강제 노출**하는 진입점을 추가한다.
+
+## 2. 핵심 결정
+
+### 노출 시점
+
+**대기방 코치마크가 처음 끝난 직후 1회**.
+
+- 이미 학습 모드에 진입한 타이밍이라 추가 다이얼로그가 자연스럽다
+- 코치마크 진행 중에는 사용자가 "준비 완료" 버튼을 못 누름 → 호스트가 게임 시작 못함 → "튜토리얼 보는 도중 GAME_START 도착" 시나리오가 구조적으로 차단된다
+- 학습-실전 간격이 짧다 (튜토리얼 끝내기 → 대기방 복귀 → 준비 완료 → 게임 시작)
+
+### UX 형태
+
+- `AppDialog.show()` 1버튼 모드 (취소 버튼 없음, "보러 가기"만)
+- `barrierDismissible: false` → 밖 영역 탭으로 닫기 불가
+- 확인 시 `context.push('/tutorial/in-game')`
+- 튜토리얼 페이지의 완료 다이얼로그는 이미 "튜토리얼 끝내기" 1버튼이라 caller-agnostic → `context.pop()`으로 대기방 복귀
+
+### 1회 보장
+
+`SharedPreferences` 키 `TutorialKeys.inGamePrompt` 신설. `all` 리스트에 포함시켜 "튜토리얼 초기화" 시 함께 reset (재노출됨).
+
+### 거절 정책
+
+거절 버튼 없음 → 의도적으로 강제. 사용자는 "보러 가기"만 누를 수 있고 그 즉시 키가 mark된다.
+
+## 3. 흐름
+
+```
+[처음 대기방 진입]
+   ↓
+대기방 코치마크 시작
+   ↓
+모든 step 통과
+   ↓
+onFinish 콜백:
+   1. TutorialService.markCompleted(TutorialKeys.waitingRoom)   ← 기존
+   2. TutorialKeys.inGamePrompt 미완료인지 확인                  ← 신규
+   3. 미완료 → mark 먼저 → AppDialog 노출 ("보러 가기")
+                ↓ (확인 탭)
+                context.push('/tutorial/in-game')
+                ↓ (튜토리얼 끝내기 탭)
+                context.pop() → 대기방 복귀
+   4. 이미 완료 → 다이얼로그 안 띄움
+```
+
+## 4. 구현 단위
+
+### 4.1 키 추가
+
+`lib/core/services/tutorial/tutorial_keys.dart`:
+```dart
+/// 대기방 코치마크 완료 후 인게임 튜토리얼 안내 다이얼로그 1회 노출용
+static const inGamePrompt = 'tutorial_in_game_prompt';
+```
+`all` 리스트에 포함.
+
+### 4.2 대기방 페이지 콜백 확장
+
+`lib/features/session/presentation/pages/waiting_room_page.dart`의 기존 `AppTutorialStyle.show(..., onFinish: ...)` 콜백을 비동기로 바꾸고 다이얼로그 호출 추가:
+
+```dart
+onFinish: () async {
+  TutorialService.markCompleted(TutorialKeys.waitingRoom);
+  _tutorialController = null;
+  _isTutorialShowing = false;
+  if (!mounted) return;
+  await _showInGameTutorialPromptIfNeeded();
+},
+
+Future<void> _showInGameTutorialPromptIfNeeded() async {
+  final shown = await TutorialService.isCompleted(TutorialKeys.inGamePrompt);
+  if (shown || !mounted) return;
+  await TutorialService.markCompleted(TutorialKeys.inGamePrompt);
+  if (!mounted) return;
+  await AppDialog.show<void>(
+    context: context,
+    title: '인게임 화면 미리 보기',
+    message: '게임이 시작되면 어떻게 동작하는지\n한 번 확인하고 시작해볼까요?',
+    confirmText: '보러 가기',
+    barrierDismissible: false,
+    onConfirm: () => context.push('/tutorial/in-game'),
+  );
+}
+```
+
+`mark`를 다이얼로그 표시 **전에** 한다 — 다이얼로그가 어떤 이유로 중단돼도 영구 재노출 방지.
+
+기존 `onFinish` cleanup 2줄(`_tutorialController = null`·`_isTutorialShowing = false`)을 그대로 유지한다. 누락하면 dispose 경로에서 dangling reference + 재진입 가드 깨짐.
+
+## 5. Edge Case
+
+| 시나리오 | 처리 |
+|---|---|
+| **S1: 튜토리얼 중 GAME_START** | 구조적 차단. 사용자가 "준비 완료" 안 눌렀으므로 호스트가 게임 시작 불가. 추가 코드 불필요. |
+| **S2: 튜토리얼 중 KICKED** | 인게임 튜토리얼 페이지는 외부 이벤트 listen 안 함. 사용자가 "튜토리얼 끝내기"로 대기방 복귀 시점에 기존 KICKED 처리 발동. 추가 코드 불필요. |
+| **S3: 시스템 뒤로가기** | `context.pop()` 허용. 대기방으로 자연 복귀. 이미 동작. |
+| **S4: 다이얼로그 중 백그라운드** | `AppDialog`의 자체 lifecycle. mark가 이미 됐으므로 복귀 시 재노출 없음. |
+| **S5: 호스트가 본인 대기방 코치마크 도중 게임 시작 시도** | 동일 — 본인 미준비 상태라 시작 불가. |
+| **S6: 대기방 재진입 시 다시 다이얼로그?** | `inGamePrompt` 키가 영구 mark되어 있어 안 뜸. 사용자가 설정 → "튜토리얼 초기화" 누르면 재노출. |
+
+## 6. 비포함 (Out of Scope)
+
+- 인게임 튜토리얼 페이지에서 외부 이벤트(GAME_START·KICKED) 직접 listen — 의존성 폭증, 현재 디자인은 자연 차단으로 해결됨
+- 거절 버튼 / "다음에 보기" 옵션 — 강제 노출 정책으로 명시 결정
+- 백엔드 API 동기화 — 로컬 SharedPreferences로 충분, 기기 변경 시 재노출은 무해
+- 대기방이 아닌 다른 화면(홈, 세션 생성, 게임 시작 직전)에서 자동 노출
+
+## 7. 테스트 (위젯 테스트)
+
+대기방의 코치마크 onFinish 콜백 분기 검증:
+
+| 케이스 | 기대 동작 |
+|---|---|
+| `inGamePrompt` 미완료 → 코치마크 onFinish 호출 | "인게임 화면 미리 보기" 다이얼로그 가시 |
+| 다이얼로그 "보러 가기" 탭 | `/tutorial/in-game` 라우트로 push |
+| `inGamePrompt` 이미 완료 → 코치마크 onFinish 호출 | 다이얼로그 안 뜸 |
+| 다이얼로그 노출 직전에 mark 완료됐는지 검증 | SharedPreferences에 `tutorial_in_game_prompt`=true |
+
+코치마크 자체 동작(GlobalKey 타깃 표시 등)은 테스트 대상 아님 (외부 라이브러리). `barrierDismissible: false` 등 dialog 옵션도 별도 테스트 안 함 (`AppDialog` 자체 책임).
+
+## 8. 디자인 시스템 준수
+
+- 다이얼로그는 `AppDialog.show()` 표준 진입점 사용 — `AppColors`·`AppTextStyles`·`AppRadius` 자동 적용
+- 추가 색상·텍스트 스타일 정의 없음
+
+## 9. 작업 항목 체크리스트
+
+- [ ] `TutorialKeys.inGamePrompt` 추가 + `all` 리스트 갱신
+- [ ] `WaitingRoomPage._showInGameTutorialPromptIfNeeded` 메서드 추가
+- [ ] 기존 코치마크 `onFinish` 콜백 → 비동기로 변경, `_showInGameTutorialPromptIfNeeded` 호출 체인
+- [ ] 위젯 테스트 추가 (`test/features/session/presentation/pages/waiting_room_page_in_game_prompt_test.dart` 등)
+- [ ] `flutter analyze lib/features/session/ lib/core/services/tutorial/` clean
+- [ ] `flutter test test/features/session/` 신규 테스트 통과

--- a/lib/core/services/tutorial/tutorial_keys.dart
+++ b/lib/core/services/tutorial/tutorial_keys.dart
@@ -13,14 +13,6 @@ class TutorialKeys {
   // 빈 슬롯"으로 호출 시점의 team 값으로 결정된다(키와 무관).
   static const waitingRoom = 'tutorial_waiting_room';
 
-  static const game = 'tutorial_game';
-  static const gameParticipants = 'tutorial_game_participants';
-
-  // 게임 진입 시 1회성 배터리 안내 다이얼로그 — 튜토리얼은 아니지만
-  // "1회만 표시 + 초기화로 재노출" 정책이 동일하므로 같이 관리.
-  static const batteryOptNotice = 'tutorial_battery_opt_notice';
-  static const batteryImpactNotice = 'tutorial_battery_impact_notice';
-
   /// 전체 키 목록 (초기화 시 사용)
   static const all = [
     home,
@@ -28,9 +20,5 @@ class TutorialKeys {
     setupPlayground,
     createStep2,
     waitingRoom,
-    game,
-    gameParticipants,
-    batteryOptNotice,
-    batteryImpactNotice,
   ];
 }

--- a/lib/core/services/tutorial/tutorial_keys.dart
+++ b/lib/core/services/tutorial/tutorial_keys.dart
@@ -13,6 +13,10 @@ class TutorialKeys {
   // 빈 슬롯"으로 호출 시점의 team 값으로 결정된다(키와 무관).
   static const waitingRoom = 'tutorial_waiting_room';
 
+  // 대기방 코치마크 완료 후 인게임 튜토리얼 페이지 안내 다이얼로그를
+  // 1회만 노출하기 위한 키. "튜토리얼 초기화" 시 함께 reset되어 재노출됨.
+  static const inGamePrompt = 'tutorial_in_game_prompt';
+
   /// 전체 키 목록 (초기화 시 사용)
   static const all = [
     home,
@@ -20,5 +24,6 @@ class TutorialKeys {
     setupPlayground,
     createStep2,
     waitingRoom,
+    inGamePrompt,
   ];
 }

--- a/lib/features/game/presentation/pages/game_page.dart
+++ b/lib/features/game/presentation/pages/game_page.dart
@@ -10,6 +10,7 @@ import 'package:geolocator/geolocator.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 
+import '../../../../core/utils/iso_timestamp_parser.dart';
 import '../../../../core/constants/app_colors.dart';
 import '../../../../core/constants/game_event_messages.dart';
 import '../../../../core/constants/spacing_and_radius.dart';

--- a/lib/features/game/presentation/pages/game_page.dart
+++ b/lib/features/game/presentation/pages/game_page.dart
@@ -11,9 +11,6 @@ import 'package:go_router/go_router.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 import '../../../../core/constants/app_colors.dart';
-import '../../../../core/services/tutorial/tutorial_keys.dart';
-import '../../../../core/services/tutorial/tutorial_service.dart';
-import '../../../../core/tutorial/app_tutorial_style.dart';
 import '../../../../core/constants/game_event_messages.dart';
 import '../../../../core/constants/spacing_and_radius.dart';
 import '../../../../core/constants/text_styles.dart';
@@ -89,12 +86,6 @@ class GamePage extends ConsumerStatefulWidget {
 class _GamePageState extends ConsumerState<GamePage>
     with WidgetsBindingObserver {
   final _googleMapKey = GlobalKey<GoogleMapViewState>();
-
-  // 튜토리얼 하이라이트 대상 키
-  final _tutorialKeyTimer = GlobalKey();
-  final _tutorialKeyParticipants = GlobalKey();
-  final _tutorialKeyMapReturn = GlobalKey();
-  final _tutorialKeyQrButton = GlobalKey();
 
   /// 채팅 시트 collapsed 상단과 우측 액션 버튼 하단 사이의 **고정 시각 여백** (논리 dp).
   ///
@@ -278,67 +269,6 @@ class _GamePageState extends ConsumerState<GamePage>
     _loadGameArea();
     _showPoliceTimerIfNeeded();
     _sendGameStartSystemMessages();
-
-    // 게임 초기화 완료 후 튜토리얼 (첫 진입 시 1회만)
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _showTutorialIfNeeded();
-    });
-  }
-
-  /// 게임 화면 튜토리얼 표시 (미완료 시 1회만 실행)
-  Future<void> _showTutorialIfNeeded() async {
-    final completed = await TutorialService.isCompleted(TutorialKeys.game);
-    if (completed || !mounted) return;
-
-    // 지도/UI 위젯 렌더링 완료 대기
-    await Future<void>.delayed(const Duration(milliseconds: 400));
-    if (!mounted) return;
-
-    AppTutorialStyle.show(
-      context: context,
-      targets: [
-        AppTutorialStyle.target(
-          keyTarget: _tutorialKeyTimer,
-          description: '남은 게임 시간이에요',
-        ),
-        AppTutorialStyle.target(
-          keyTarget: _tutorialKeyParticipants,
-          description: '참가자 목록과 QR 체포/탈옥은 여기서 확인해요',
-        ),
-      ],
-      onFinish: () => TutorialService.markCompleted(TutorialKeys.game),
-    );
-  }
-
-  /// 참가자 목록 화면 튜토리얼 (지도 복귀 + QR 안내)
-  Future<void> _showParticipantsTutorialIfNeeded() async {
-    final completed = await TutorialService.isCompleted(
-      TutorialKeys.gameParticipants,
-    );
-    if (completed || !mounted) return;
-
-    await Future<void>.delayed(const Duration(milliseconds: 400));
-    if (!mounted) return;
-
-    final targets = [
-      AppTutorialStyle.target(
-        keyTarget: _tutorialKeyMapReturn,
-        description: '지도 화면으로 돌아갈 수 있어요',
-      ),
-      AppTutorialStyle.target(
-        keyTarget: _tutorialKeyQrButton,
-        description: widget.team == 'POLICE'
-            ? '도둑의 QR을 스캔해서 체포해요'
-            : '잡히면 경찰에게 QR을 보여주고, 경찰이 스캔하면 체포돼요',
-      ),
-    ];
-
-    AppTutorialStyle.show(
-      context: context,
-      targets: targets,
-      onFinish: () =>
-          TutorialService.markCompleted(TutorialKeys.gameParticipants),
-    );
   }
 
   /// 앱 포그라운드 복귀 시 위치 권한 재확인
@@ -1559,7 +1489,6 @@ class _GamePageState extends ConsumerState<GamePage>
               child: Column(
                 children: [
                   SvgIconButton(
-                    key: _tutorialKeyMapReturn,
                     assetPath: 'assets/icons/icon_map.svg',
                     onPressed: () => setState(() => _showParticipants = false),
                     containerSize: 48,
@@ -1579,12 +1508,9 @@ class _GamePageState extends ConsumerState<GamePage>
               child: Column(
                 children: [
                   SvgIconButton(
-                    key: _tutorialKeyParticipants,
                     assetPath: 'assets/icons/icon_person.svg',
-                    onPressed: () {
-                      setState(() => _showParticipants = true);
-                      _showParticipantsTutorialIfNeeded();
-                    },
+                    onPressed: () =>
+                        setState(() => _showParticipants = true),
                     containerSize: 48,
                     iconSize: 24,
                     iconColor: _isDarkMode ? AppColors.green : AppColors.blue,
@@ -1693,7 +1619,6 @@ class _GamePageState extends ConsumerState<GamePage>
   /// QR 버튼 (경찰: 스캔, 도둑: QR 표시)
   Widget _buildQrButton() {
     return SvgIconButton(
-      key: _tutorialKeyQrButton,
       assetPath: widget.team == 'POLICE'
           ? 'assets/icons/icon_qr_scan.svg'
           : 'assets/icons/icon_qr_code.svg',
@@ -1815,7 +1740,6 @@ class _GamePageState extends ConsumerState<GamePage>
         children: [
           // 중앙: 타이머 + 서브 타이머
           Column(
-            key: _tutorialKeyTimer,
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               // START 이벤트 수신 후 경과 시간 표시

--- a/lib/features/game/presentation/pages/game_page.dart
+++ b/lib/features/game/presentation/pages/game_page.dart
@@ -1509,8 +1509,7 @@ class _GamePageState extends ConsumerState<GamePage>
                 children: [
                   SvgIconButton(
                     assetPath: 'assets/icons/icon_person.svg',
-                    onPressed: () =>
-                        setState(() => _showParticipants = true),
+                    onPressed: () => setState(() => _showParticipants = true),
                     containerSize: 48,
                     iconSize: 24,
                     iconColor: _isDarkMode ? AppColors.green : AppColors.blue,

--- a/lib/features/session/presentation/pages/session_creation_flow_page.dart
+++ b/lib/features/session/presentation/pages/session_creation_flow_page.dart
@@ -74,9 +74,7 @@ class _SessionCreationFlowPageState
   final _tutorialKeyPlayground = GlobalKey();
   // Step 1
   // Step 2
-  final _tutorialKeyRoundDuration = GlobalKey();
-  final _tutorialKeyLocationShare = GlobalKey();
-  final _tutorialKeyPoliceWait = GlobalKey();
+  final _tutorialKeySettings = GlobalKey();
   // Step 3
 
   // Step 0: 구역 선택
@@ -165,16 +163,9 @@ class _SessionCreationFlowPageState
       case 2:
         return [
           AppTutorialStyle.target(
-            keyTarget: _tutorialKeyRoundDuration,
-            description: '한 라운드의 제한 시간이에요\n숫자를 탭하면 직접 입력할 수 있어요',
-          ),
-          AppTutorialStyle.target(
-            keyTarget: _tutorialKeyLocationShare,
-            description: '도둑 위치가 경찰에게 공개되는 주기에요',
-          ),
-          AppTutorialStyle.target(
-            keyTarget: _tutorialKeyPoliceWait,
-            description: '게임 시작 후 경찰이 출발할 때까지 기다리는 시간이에요',
+            keyTarget: _tutorialKeySettings,
+            description:
+                '게임 규칙을 정해요\n숫자를 탭하면 직접 입력할 수 있어요',
           ),
         ];
       default:
@@ -656,9 +647,7 @@ class _SessionCreationFlowPageState
             onRoundDurationChanged: _onRoundDurationChanged,
             onLocationShareChanged: _onLocationShareChanged,
             onPoliceWaitChanged: _onPoliceWaitChanged,
-            roundDurationKey: _tutorialKeyRoundDuration,
-            locationShareKey: _tutorialKeyLocationShare,
-            policeWaitKey: _tutorialKeyPoliceWait,
+            settingsKey: _tutorialKeySettings,
           ),
         ),
 

--- a/lib/features/session/presentation/pages/session_creation_flow_page.dart
+++ b/lib/features/session/presentation/pages/session_creation_flow_page.dart
@@ -164,8 +164,7 @@ class _SessionCreationFlowPageState
         return [
           AppTutorialStyle.target(
             keyTarget: _tutorialKeySettings,
-            description:
-                '게임 규칙을 정해요\n숫자를 탭하면 직접 입력할 수 있어요',
+            description: '게임 규칙을 정해요\n숫자를 탭하면 직접 입력할 수 있어요',
           ),
         ];
       default:

--- a/lib/features/session/presentation/pages/waiting_room_page.dart
+++ b/lib/features/session/presentation/pages/waiting_room_page.dart
@@ -561,11 +561,37 @@ class _WaitingRoomPageState extends ConsumerState<WaitingRoomPage>
     _tutorialController = AppTutorialStyle.show(
       context: context,
       targets: targets,
-      onFinish: () {
+      onFinish: () async {
         TutorialService.markCompleted(key);
         _tutorialController = null;
         _isTutorialShowing = false;
+        if (!mounted) return;
+        await _showInGameTutorialPromptIfNeeded();
       },
+    );
+  }
+
+  /// 대기방 코치마크가 처음 끝난 직후 1회 노출되는 인게임 튜토리얼 안내.
+  ///
+  /// 키가 이미 mark되어 있으면 아무 동작도 하지 않는다.
+  /// 다이얼로그 표시 **전에** mark를 수행해 어떤 이유로 다이얼로그가
+  /// 중단되더라도 영구 재노출을 방지한다.
+  Future<void> _showInGameTutorialPromptIfNeeded() async {
+    final shown = await TutorialService.isCompleted(
+      TutorialKeys.inGamePrompt,
+    );
+    if (shown || !mounted) return;
+
+    await TutorialService.markCompleted(TutorialKeys.inGamePrompt);
+    if (!mounted) return;
+
+    await AppDialog.show<void>(
+      context: context,
+      title: '인게임 화면 미리 보기',
+      message: '게임이 시작되면 어떻게 동작하는지\n한 번 확인하고 시작해볼까요?',
+      confirmText: '보러 가기',
+      barrierDismissible: false,
+      onConfirm: () => context.push('/tutorial/in-game'),
     );
   }
 

--- a/lib/features/session/presentation/pages/waiting_room_page.dart
+++ b/lib/features/session/presentation/pages/waiting_room_page.dart
@@ -562,7 +562,7 @@ class _WaitingRoomPageState extends ConsumerState<WaitingRoomPage>
       context: context,
       targets: targets,
       onFinish: () async {
-        TutorialService.markCompleted(key);
+        await TutorialService.markCompleted(key);
         _tutorialController = null;
         _isTutorialShowing = false;
         if (!mounted) return;
@@ -577,9 +577,7 @@ class _WaitingRoomPageState extends ConsumerState<WaitingRoomPage>
   /// 다이얼로그 표시 **전에** mark를 수행해 어떤 이유로 다이얼로그가
   /// 중단되더라도 영구 재노출을 방지한다.
   Future<void> _showInGameTutorialPromptIfNeeded() async {
-    final shown = await TutorialService.isCompleted(
-      TutorialKeys.inGamePrompt,
-    );
+    final shown = await TutorialService.isCompleted(TutorialKeys.inGamePrompt);
     if (shown || !mounted) return;
 
     await TutorialService.markCompleted(TutorialKeys.inGamePrompt);
@@ -591,6 +589,8 @@ class _WaitingRoomPageState extends ConsumerState<WaitingRoomPage>
       message: '게임이 시작되면 어떻게 동작하는지\n한 번 확인하고 시작해볼까요?',
       confirmText: '보러 가기',
       barrierDismissible: false,
+      // 도둑팀 사용자의 다크 화면 위에 라이트 다이얼로그가 뜨는 부조화 방지
+      isDarkMode: ref.read(roleThemeProvider),
       onConfirm: () => context.push('/tutorial/in-game'),
     );
   }

--- a/lib/features/session/presentation/widgets/game_rules_content.dart
+++ b/lib/features/session/presentation/widgets/game_rules_content.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../../../core/constants/app_colors.dart';
 import '../../../../core/constants/spacing_and_radius.dart';
@@ -43,9 +44,13 @@ class GameRulesContent extends StatelessWidget {
         locationRevealIntervalMinutes: locationRevealIntervalMinutes,
         isDarkMode: isDarkMode,
       ),
-      confirmText: '확인했어요!',
+      // 좌측은 단순 닫기, 우측 primary로 인게임 튜토리얼 재방문 경로 노출.
+      // 한 번 본 사용자도 게임 규칙 다이얼로그를 통해 언제든 다시 학습 가능.
+      cancelText: '확인',
+      confirmText: '인게임 보기',
       confirmColor: isDarkMode ? null : AppColors.blue,
       confirmTextColor: isDarkMode ? null : AppColors.white,
+      onConfirm: () => context.push('/tutorial/in-game'),
     );
   }
 

--- a/lib/features/session/presentation/widgets/session_creation_steps/step_2_game_settings_content.dart
+++ b/lib/features/session/presentation/widgets/session_creation_steps/step_2_game_settings_content.dart
@@ -21,9 +21,7 @@ class Step2GameSettingsContent extends StatelessWidget {
     required this.onPoliceWaitChanged,
     this.isDarkMode = false,
     this.valueTextStyle,
-    this.roundDurationKey,
-    this.locationShareKey,
-    this.policeWaitKey,
+    this.settingsKey,
   });
 
   // ============================================
@@ -57,14 +55,10 @@ class Step2GameSettingsContent extends StatelessWidget {
   /// Step 1과 동일한 시그니처를 유지한다.
   final TextStyle? valueTextStyle;
 
-  /// 튜토리얼 하이라이트용 — 라운드 제한 시간 슬라이더
-  final GlobalKey? roundDurationKey;
-
-  /// 튜토리얼 하이라이트용 — 위치 공유 간격 슬라이더
-  final GlobalKey? locationShareKey;
-
-  /// 튜토리얼 하이라이트용 — 경찰 출동 시간 슬라이더
-  final GlobalKey? policeWaitKey;
+  /// 튜토리얼 하이라이트용 — 슬라이더 3개를 묶은 컨테이너 키
+  ///
+  /// 세 슬라이더 UI가 동일하므로 각각 하이라이트하지 않고 하나로 묶어 안내한다.
+  final GlobalKey? settingsKey;
 
   // ============================================
   // Build Methods
@@ -74,10 +68,10 @@ class Step2GameSettingsContent extends StatelessWidget {
   Widget build(BuildContext context) {
     debugPrint('🔍 Step2 isDarkMode: $isDarkMode');
     return Column(
+      key: settingsKey,
       children: [
         // 라운드 제한 시간
         AppSlider(
-          key: roundDurationKey,
           label: '라운드 제한 시간',
           value: roundDurationMinutes.toDouble(),
           min: 10,
@@ -95,7 +89,6 @@ class Step2GameSettingsContent extends StatelessWidget {
 
         // 위치 공유 간격
         AppSlider(
-          key: locationShareKey,
           label: '도둑 위치 공유 간격',
           value: locationShareMinutes.toDouble(),
 
@@ -115,7 +108,6 @@ class Step2GameSettingsContent extends StatelessWidget {
 
         // 경찰 출동 시간 (도둑 도망 후)
         AppSlider(
-          key: policeWaitKey,
           label: '경찰 출동 시간',
           value: policeWaitMinutes.toDouble(),
           min: 1,

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -17,6 +17,7 @@ import '../../../../core/widgets/buttons/previous_button.dart';
 import '../../../../core/widgets/dialogs/app_dialog.dart';
 import '../../../../core/services/loading_message_service.dart';
 import '../../../../core/widgets/dialogs/app_popup.dart';
+import '../../../../core/services/tutorial/tutorial_service.dart';
 import '../../../../core/widgets/snackbars/app_snackbar.dart';
 import '../../../../core/widgets/dialogs/dialog_animation.dart';
 import '../../../../core/widgets/inputs/app_text_field.dart';
@@ -26,7 +27,6 @@ import '../../../bug/presentation/providers/bug_provider.dart';
 import '../../../user/presentation/providers/user_provider.dart';
 import '../../../../core/widgets/pages/text_submit_page.dart';
 import '../../../credits/presentation/pages/credits_page.dart';
-import '../../../../core/services/tutorial/tutorial_service.dart';
 import 'agreement_settings_page.dart';
 
 /// 설정 페이지
@@ -411,7 +411,11 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
     }
   }
 
-  /// 튜토리얼 초기화
+  /// 튜토리얼 초기화 (코치마크 한정)
+  ///
+  /// SharedPreferences의 모든 코치마크 키를 삭제하고, 신호를 발행해
+  /// 부모 위젯이 dispose되지 않은 화면도 즉시 재노출되게 한다.
+  /// 마지막에 홈으로 이동해 첫 코치마크가 바로 떠 보이도록 한다.
   Future<void> _onResetTutorial() async {
     final result = await AppDialog.confirm(
       context: context,
@@ -424,7 +428,6 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
     await TutorialService.resetAll();
     if (!mounted) return;
 
-    // HomePage는 settings 상위라 initState가 재실행되지 않음 → 신호로 튜토리얼 재노출 트리거
     ref.read(tutorialResetSignalProvider.notifier).state++;
     AppSnackbar.show(context, message: '튜토리얼이 초기화되었어요');
     context.go(RoutePaths.home);

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -148,6 +148,11 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
             _buildItemDivider(),
             _buildMenuItem(text: '버그 제보', onTap: _onBugReport),
             _buildItemDivider(),
+            _buildMenuItem(
+              text: '튜토리얼 다시 보기',
+              onTap: () => context.push('/tutorial'),
+            ),
+            _buildItemDivider(),
             _buildMenuItem(text: '튜토리얼 초기화', onTap: _onResetTutorial),
             _buildItemDivider(),
             _buildMenuItem(

--- a/lib/features/tutorial/presentation/pages/in_game_tutorial_page.dart
+++ b/lib/features/tutorial/presentation/pages/in_game_tutorial_page.dart
@@ -153,7 +153,7 @@ class _InGameTutorialPageState extends State<InGameTutorialPage>
       context: context,
       title: '튜토리얼 완료!',
       message: '핵심 흐름을 익혔어요\n실제 게임에서 활용해보세요',
-      confirmText: '카탈로그로 돌아가기',
+      confirmText: '튜토리얼 끝내기',
       onConfirm: () => context.pop(),
       isDarkMode: _isDarkMode,
     );

--- a/lib/features/tutorial/presentation/pages/in_game_tutorial_page.dart
+++ b/lib/features/tutorial/presentation/pages/in_game_tutorial_page.dart
@@ -229,12 +229,7 @@ class _InGameTutorialPageState extends State<InGameTutorialPage>
             color: _isDarkMode ? AppColors.black900 : AppColors.white,
             child: SafeArea(
               bottom: false,
-              child: Column(
-                children: [
-                  _buildTopBar(),
-                  _buildMissionBanner(),
-                ],
-              ),
+              child: Column(children: [_buildTopBar(), _buildMissionBanner()]),
             ),
           ),
         ),
@@ -255,8 +250,7 @@ class _InGameTutorialPageState extends State<InGameTutorialPage>
                   },
                   containerSize: 48,
                   iconSize: 24,
-                  iconColor:
-                      _isDarkMode ? AppColors.green : AppColors.blue,
+                  iconColor: _isDarkMode ? AppColors.green : AppColors.blue,
                   backgroundColor: _isDarkMode ? AppColors.black : null,
                 ),
               ),
@@ -342,8 +336,7 @@ class _InGameTutorialPageState extends State<InGameTutorialPage>
                   },
                   containerSize: 48,
                   iconSize: 24,
-                  iconColor:
-                      _isDarkMode ? AppColors.green : AppColors.blue,
+                  iconColor: _isDarkMode ? AppColors.green : AppColors.blue,
                   backgroundColor: _isDarkMode ? AppColors.black : null,
                 ),
               ),
@@ -513,15 +506,10 @@ class _InGameTutorialPageState extends State<InGameTutorialPage>
   Widget _buildMissionBanner() {
     if (_missionStep >= 3) return const SizedBox.shrink();
 
-    const descriptions = [
-      '참가자 보기 버튼을 눌러보세요',
-      'QR 버튼을 눌러보세요',
-      '지도로 돌아가 보세요',
-    ];
+    const descriptions = ['참가자 보기 버튼을 눌러보세요', 'QR 버튼을 눌러보세요', '지도로 돌아가 보세요'];
 
     final accentColor = _isDarkMode ? AppColors.green : AppColors.blue;
-    final bgColor =
-        _isDarkMode ? AppColors.black800 : AppColors.blue100;
+    final bgColor = _isDarkMode ? AppColors.black800 : AppColors.blue100;
     final descColor = _isDarkMode ? AppColors.white : AppColors.black800;
 
     return Container(

--- a/lib/features/tutorial/presentation/pages/in_game_tutorial_page.dart
+++ b/lib/features/tutorial/presentation/pages/in_game_tutorial_page.dart
@@ -15,8 +15,6 @@ import '../../../../core/widgets/dialogs/app_dialog.dart';
 import '../../../../core/widgets/snackbars/app_snackbar.dart';
 import '../../../chat/presentation/widgets/chat_overlay.dart'
     show kChatOverlayCollapsedFixedHeight;
-import '../../../game/presentation/widgets/game_timer_text.dart';
-import '../../../game/presentation/widgets/location_reveal_countdown.dart';
 import '../../../lobby/data/models/lobby_event_dto.dart';
 import '../../../session/presentation/widgets/team_section.dart';
 
@@ -52,15 +50,6 @@ class _InGameTutorialPageState extends State<InGameTutorialPage>
 
   /// 참가자 화면 — 도둑팀 접힘/펼침 (실제 ParticipantOverlay 기본값과 동일)
   bool _isRobberExpanded = true;
-
-  /// 데모용 게임 시작 시각 — 30분 라운드 중 30초 경과 상태로 보여준다
-  late final DateTime _demoStartTime;
-
-  /// 데모용 다음 도둑 위치 공개 시각 — 약 4분 30초 남은 상태
-  late final DateTime _demoNextRevealTime;
-
-  static const Duration _demoRoundDuration = Duration(minutes: 30);
-  static const int _demoLocationRevealInterval = 5;
 
   // 데모 참가자 데이터 — 호스트는 경찰1, 본인은 도둑이게아니게
   static const int _demoHostParticipantId = 1;
@@ -119,10 +108,6 @@ class _InGameTutorialPageState extends State<InGameTutorialPage>
   @override
   void initState() {
     super.initState();
-    final now = DateTime.now();
-    _demoStartTime = now.subtract(const Duration(seconds: 30));
-    _demoNextRevealTime = now.add(const Duration(minutes: 4, seconds: 30));
-
     _pulseController = AnimationController(
       vsync: this,
       duration: const Duration(milliseconds: 1200),
@@ -440,16 +425,23 @@ class _InGameTutorialPageState extends State<InGameTutorialPage>
           Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              GameTimerText(
-                startTime: _demoStartTime,
-                totalDuration: _demoRoundDuration,
-                isDarkMode: _isDarkMode,
+              // 튜토리얼은 정적 미리보기 — 실 GameTimerText/LocationRevealCountdown은
+              // 매초 setState로 재빌드되어 학습용 화면에서는 불필요한 부담.
+              // 외형(스타일/텍스트 위치)은 그대로 복제하고 값만 고정.
+              Text(
+                '29:30',
+                style: _isDarkMode
+                    ? AppTextStyles.robberHeading.copyWith(
+                        color: AppColors.white,
+                      )
+                    : AppTextStyles.heading_20.copyWith(color: AppColors.black),
               ),
               SizedBox(height: 6.h),
-              LocationRevealCountdown(
-                nextRevealTime: _demoNextRevealTime,
-                intervalMinutes: _demoLocationRevealInterval,
-                isDarkMode: _isDarkMode,
+              Text(
+                '다음 도둑 위치 공개까지 04:30',
+                style: AppTextStyles.tag_12.copyWith(
+                  color: _isDarkMode ? AppColors.black400 : AppColors.red,
+                ),
               ),
             ],
           ),

--- a/lib/features/tutorial/presentation/pages/in_game_tutorial_page.dart
+++ b/lib/features/tutorial/presentation/pages/in_game_tutorial_page.dart
@@ -1,0 +1,893 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/constants/app_colors.dart';
+import '../../../../core/constants/spacing_and_radius.dart';
+import '../../../../core/constants/text_styles.dart';
+import '../../../../core/services/vibration_service.dart';
+import '../../../../core/widgets/buttons/my_location_button.dart';
+import '../../../../core/widgets/buttons/svg_icon_button.dart';
+import '../../../../core/widgets/dialogs/app_dialog.dart';
+import '../../../../core/widgets/snackbars/app_snackbar.dart';
+import '../../../chat/presentation/widgets/chat_overlay.dart'
+    show kChatOverlayCollapsedFixedHeight;
+import '../../../game/presentation/widgets/game_timer_text.dart';
+import '../../../game/presentation/widgets/location_reveal_countdown.dart';
+import '../../../lobby/data/models/lobby_event_dto.dart';
+import '../../../session/presentation/widgets/team_section.dart';
+
+/// 인게임 화면 튜토리얼
+///
+/// 실제 게임 화면(`GamePage`) 레이아웃을 그대로 본떠서 만든 튜토리얼 뷰.
+/// 외부 데이터 의존성(STOMP, Riverpod provider, GPS)은 차단하고
+/// 버튼 액션은 [AppSnackbar]로 안내한다.
+///
+/// 정책
+/// - 별도 [AppBar] 없음. 좌측 상단 뒤로가기 버튼 오버레이만.
+/// - 지도는 실 [GoogleMapView] 대신 격자 placeholder(권한 요청 회피).
+/// - 채팅 시트는 collapsed 시각을 정밀 복제 (드래그/입력 동작 없음).
+/// - 팀 시점 토글은 지도 placeholder 중앙에 배치 (가독성).
+/// - 참가자 목록은 실 [TeamSection] + [ParticipantCard] 재사용.
+class InGameTutorialPage extends StatefulWidget {
+  const InGameTutorialPage({super.key});
+
+  @override
+  State<InGameTutorialPage> createState() => _InGameTutorialPageState();
+}
+
+class _InGameTutorialPageState extends State<InGameTutorialPage>
+    with SingleTickerProviderStateMixin {
+  /// 도둑 모드 토글 (false = 경찰/라이트, true = 도둑/다크)
+  bool _isDarkMode = false;
+
+  /// 참가자 목록 모드 (실제 게임에서 person 버튼 누르면 전환되는 화면)
+  bool _showParticipants = false;
+
+  /// 참가자 화면 — 경찰팀 접힘/펼침
+  bool _isPoliceExpanded = false;
+
+  /// 참가자 화면 — 도둑팀 접힘/펼침 (실제 ParticipantOverlay 기본값과 동일)
+  bool _isRobberExpanded = true;
+
+  /// 데모용 게임 시작 시각 — 30분 라운드 중 30초 경과 상태로 보여준다
+  late final DateTime _demoStartTime;
+
+  /// 데모용 다음 도둑 위치 공개 시각 — 약 4분 30초 남은 상태
+  late final DateTime _demoNextRevealTime;
+
+  static const Duration _demoRoundDuration = Duration(minutes: 30);
+  static const int _demoLocationRevealInterval = 5;
+
+  // 데모 참가자 데이터 — 호스트는 경찰1, 본인은 도둑이게아니게
+  static const int _demoHostParticipantId = 1;
+  static const int _demoMyParticipantId = 11;
+
+  /// 데모 경찰팀 (1명)
+  static const List<LobbyParticipantInfo> _demoPolice = [
+    LobbyParticipantInfo(
+      participantId: 1,
+      nickname: '경찰1',
+      team: 'POLICE',
+      isReady: true,
+    ),
+  ];
+
+  /// 데모 도둑팀 (3명: 도주 2 + 수감 1)
+  static const List<LobbyParticipantInfo> _demoRobbers = [
+    LobbyParticipantInfo(
+      participantId: 10,
+      nickname: '도둑킹',
+      team: 'ROBBER',
+      isReady: false, // ALIVE → 도주 중
+    ),
+    LobbyParticipantInfo(
+      participantId: 11,
+      nickname: '도둑이게아니게',
+      team: 'ROBBER',
+      isReady: false, // ALIVE → 도주 중 (본인)
+    ),
+    LobbyParticipantInfo(
+      participantId: 12,
+      nickname: '잡힌도둑',
+      team: 'ROBBER',
+      isReady: true, // JAILED
+    ),
+  ];
+
+  /// 게임 컨텍스트 상태 맵 (ParticipantCard 의 SVG 분기에 사용)
+  Map<int, String> get _demoGameStatus => const {
+    1: 'POLICE_WAITING',
+    10: 'ALIVE',
+    11: 'ALIVE',
+    12: 'JAILED',
+  };
+
+  /// 미션 진행도 (0=참가자, 1=QR, 2=지도복귀, 3=완료)
+  int _missionStep = 0;
+
+  /// 펄스 애니메이션 컨트롤러 (활성 미션 타깃 버튼 강조용).
+  ///
+  /// 레이더 핑 효과 — `repeat()` (reverse 없음)으로 매 사이클마다
+  /// 외곽 ring이 1.0 → 1.8 확장하며 페이드아웃, 다음 사이클 시작 시 1.0으로 스냅.
+  /// 버튼 자체 scale은 sin 곡선으로 1.0 → 1.18 → 1.0 부드럽게 왕복.
+  late final AnimationController _pulseController;
+
+  @override
+  void initState() {
+    super.initState();
+    final now = DateTime.now();
+    _demoStartTime = now.subtract(const Duration(seconds: 30));
+    _demoNextRevealTime = now.add(const Duration(minutes: 4, seconds: 30));
+
+    _pulseController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1200),
+    )..repeat();
+  }
+
+  @override
+  void dispose() {
+    _pulseController.dispose();
+    super.dispose();
+  }
+
+  /// 정답 버튼 탭 시 미션 진행
+  void _tryAdvanceMission(int expectedStep) {
+    if (_missionStep != expectedStep) return;
+    VibrationService.instance().buttonTap();
+    setState(() => _missionStep++);
+    if (_missionStep >= 3) {
+      // 화면 전환(_showParticipants=false) 후 살짝 텀 두고 다이얼로그
+      Future.delayed(const Duration(milliseconds: 500), _showCompletionDialog);
+    }
+  }
+
+  /// 완료 다이얼로그
+  void _showCompletionDialog() {
+    if (!mounted) return;
+    AppDialog.show<void>(
+      context: context,
+      title: '튜토리얼 완료!',
+      message: '핵심 흐름을 익혔어요\n실제 게임에서 활용해보세요',
+      confirmText: '카탈로그로 돌아가기',
+      onConfirm: () => context.pop(),
+      isDarkMode: _isDarkMode,
+    );
+  }
+
+  /// 활성 미션 타깃 버튼에 레이더 핑 펄스 애니메이션을 입힌다.
+  ///
+  /// 두 레이어:
+  /// 1. **외곽 ring** — 팀 컬러 보더만 있는 둥근 사각형이 1.0 → 1.8로 확장하며
+  ///    opacity 1.0 → 0.0 페이드아웃. 시각적으로 "핑" 신호처럼 퍼져나간다.
+  /// 2. **버튼 본체** — sin 곡선 기반 1.0 → 1.18 → 1.0 부드러운 왕복.
+  ///
+  /// `clipBehavior: Clip.none`으로 ring이 SizedBox 경계 밖으로 자연스럽게 확장.
+  Widget _pulseIfActive({required int step, required Widget child}) {
+    if (_missionStep != step) return child;
+
+    final accentColor = _isDarkMode ? AppColors.green : AppColors.blue;
+
+    return SizedBox(
+      width: 48.w,
+      height: 48.w,
+      child: AnimatedBuilder(
+        animation: _pulseController,
+        builder: (_, _) {
+          final t = _pulseController.value; // 0.0 → 1.0
+          final ringScale = 1.0 + t * 0.8; // 1.0 → 1.8
+          final ringOpacity = 1.0 - t; // 1.0 → 0.0
+          final buttonScale = 1.0 + math.sin(t * math.pi) * 0.18;
+
+          return Stack(
+            alignment: Alignment.center,
+            clipBehavior: Clip.none,
+            children: [
+              Opacity(
+                opacity: ringOpacity,
+                child: Transform.scale(
+                  scale: ringScale,
+                  child: Container(
+                    width: 48.w,
+                    height: 48.w,
+                    decoration: BoxDecoration(
+                      border: Border.all(color: accentColor, width: 2.5),
+                      borderRadius: BorderRadius.circular(16.r),
+                    ),
+                  ),
+                ),
+              ),
+              Transform.scale(scale: buttonScale, child: child),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      resizeToAvoidBottomInset: false,
+      backgroundColor: _isDarkMode ? AppColors.black800 : AppColors.white,
+      body: _showParticipants ? _buildParticipantsMode() : _buildMapMode(),
+    );
+  }
+
+  // ============================================================================
+  // 모드별 레이아웃
+  // ============================================================================
+
+  /// 지도 모드 (기본 화면)
+  Widget _buildMapMode() {
+    final viewPaddingBottom = MediaQuery.of(context).viewPadding.bottom;
+    // 실제 GamePage._kActionButtonChatGap(45) + kChatOverlayCollapsedFixedHeight(112)
+    // + 시스템 네비 inset(viewPadding.bottom).
+    final actionButtonBottom =
+        kChatOverlayCollapsedFixedHeight.h + 45.h + viewPaddingBottom;
+
+    return Stack(
+      children: [
+        // 0. 지도 (status bar까지 깔림)
+        Positioned.fill(child: _buildMapPlaceholder()),
+
+        // 1. 상단 타이머 바 + 미션 배너
+        Positioned(
+          top: 0,
+          left: 0,
+          right: 0,
+          child: Container(
+            color: _isDarkMode ? AppColors.black900 : AppColors.white,
+            child: SafeArea(
+              bottom: false,
+              child: Column(
+                children: [
+                  _buildTopBar(),
+                  _buildMissionBanner(),
+                ],
+              ),
+            ),
+          ),
+        ),
+
+        // 2. 우측 액션 버튼 — 실제 GamePage와 동일하게 [참가자, 내 위치] 2개
+        Positioned(
+          right: 20.w,
+          bottom: actionButtonBottom,
+          child: Column(
+            children: [
+              _pulseIfActive(
+                step: 0,
+                child: SvgIconButton(
+                  assetPath: 'assets/icons/icon_person.svg',
+                  onPressed: () {
+                    _tryAdvanceMission(0);
+                    setState(() => _showParticipants = true);
+                  },
+                  containerSize: 48,
+                  iconSize: 24,
+                  iconColor:
+                      _isDarkMode ? AppColors.green : AppColors.blue,
+                  backgroundColor: _isDarkMode ? AppColors.black : null,
+                ),
+              ),
+              SizedBox(height: AppSpacing.vertical8),
+              MyLocationButton(
+                onPressed: () {
+                  AppSnackbar.show(
+                    context,
+                    message: '내 위치로 카메라가 이동했어요',
+                    isDarkMode: _isDarkMode,
+                  );
+                },
+                isFocused: true,
+                containerSize: 48,
+                iconSize: 24,
+                focusedColor: _isDarkMode ? AppColors.green : null,
+                unfocusedColor: _isDarkMode ? AppColors.green500 : null,
+                backgroundColor: _isDarkMode ? AppColors.black : null,
+              ),
+            ],
+          ),
+        ),
+
+        // 3. 하단 채팅 collapsed placeholder
+        Positioned(
+          left: 0,
+          right: 0,
+          bottom: 0,
+          child: _buildChatCollapsedReplica(),
+        ),
+
+        // 4. 좌측 상단 뒤로가기
+        Positioned(
+          top: 0,
+          left: 0,
+          child: SafeArea(bottom: false, child: _buildBackButton()),
+        ),
+      ],
+    );
+  }
+
+  /// 참가자 모드 — 실제 [ParticipantOverlay]와 동일 구조
+  ///
+  /// 실제 [GamePage] Stack에서 [ChatOverlay]는 `_showParticipants` 분기 바깥
+  /// (index 7)에 고정되어 참가자 모드에서도 항상 노출된다. 본 튜토리얼도
+  /// 동일하게 채팅 collapsed placeholder를 항상 렌더링.
+  Widget _buildParticipantsMode() {
+    final viewPaddingBottom = MediaQuery.of(context).viewPadding.bottom;
+    final actionButtonBottom =
+        kChatOverlayCollapsedFixedHeight.h + 45.h + viewPaddingBottom;
+
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: Container(
+            color: _isDarkMode ? AppColors.black900 : AppColors.white,
+            child: SafeArea(
+              bottom: false,
+              child: Column(
+                children: [
+                  _buildTopBar(),
+                  _buildMissionBanner(),
+                  Expanded(child: _buildParticipantsList()),
+                ],
+              ),
+            ),
+          ),
+        ),
+
+        // 우측 액션 [지도 복귀, QR]
+        Positioned(
+          right: 20.w,
+          bottom: actionButtonBottom,
+          child: Column(
+            children: [
+              _pulseIfActive(
+                step: 2,
+                child: SvgIconButton(
+                  assetPath: 'assets/icons/icon_map.svg',
+                  onPressed: () {
+                    _tryAdvanceMission(2);
+                    setState(() => _showParticipants = false);
+                  },
+                  containerSize: 48,
+                  iconSize: 24,
+                  iconColor:
+                      _isDarkMode ? AppColors.green : AppColors.blue,
+                  backgroundColor: _isDarkMode ? AppColors.black : null,
+                ),
+              ),
+              SizedBox(height: AppSpacing.vertical8),
+              _buildQrButton(),
+            ],
+          ),
+        ),
+
+        // 하단 채팅 collapsed placeholder (참가자 모드에서도 항상 노출)
+        Positioned(
+          left: 0,
+          right: 0,
+          bottom: 0,
+          child: _buildChatCollapsedReplica(),
+        ),
+
+        // 좌측 상단 뒤로가기
+        Positioned(
+          top: 0,
+          left: 0,
+          child: SafeArea(bottom: false, child: _buildBackButton()),
+        ),
+      ],
+    );
+  }
+
+  // ============================================================================
+  // 지도 placeholder
+  // ============================================================================
+
+  /// 지도 영역 placeholder — 격자 + 안내 텍스트 + 팀 시점 토글
+  ///
+  /// 실제 [GoogleMapView]는 위치 권한을 요청하므로 튜토리얼에선 격자로 대체.
+  /// 토글은 가독성을 위해 placeholder 중앙에 배치한다.
+  Widget _buildMapPlaceholder() {
+    return Container(
+      color: _isDarkMode ? AppColors.black800 : AppColors.black100,
+      child: CustomPaint(
+        painter: _MapGridPainter(isDarkMode: _isDarkMode),
+        child: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                Icons.map_outlined,
+                size: 56.w,
+                color: _isDarkMode ? AppColors.black600 : AppColors.black300,
+              ),
+              SizedBox(height: AppSpacing.vertical8),
+              Text(
+                '지도 미리보기',
+                style: AppTextStyles.paragraph_14.copyWith(
+                  color: _isDarkMode ? AppColors.black400 : AppColors.black500,
+                ),
+              ),
+              SizedBox(height: AppSpacing.vertical16),
+              _buildTeamToggle(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  // ============================================================================
+  // 상단 바
+  // ============================================================================
+
+  /// 상단 바 — 실제 [GamePage._buildAppBar]와 동일한 구조
+  Widget _buildTopBar() {
+    return Container(
+      height: 64.h,
+      color: _isDarkMode ? AppColors.black900 : AppColors.white,
+      padding: EdgeInsets.symmetric(horizontal: AppSpacing.horizontal12),
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              GameTimerText(
+                startTime: _demoStartTime,
+                totalDuration: _demoRoundDuration,
+                isDarkMode: _isDarkMode,
+              ),
+              SizedBox(height: 6.h),
+              LocationRevealCountdown(
+                nextRevealTime: _demoNextRevealTime,
+                intervalMinutes: _demoLocationRevealInterval,
+                isDarkMode: _isDarkMode,
+              ),
+            ],
+          ),
+          Align(
+            alignment: Alignment.centerRight,
+            child: GestureDetector(
+              onTap: () {
+                AppSnackbar.show(
+                  context,
+                  message: '게임 룰 안내가 열려요',
+                  isDarkMode: _isDarkMode,
+                );
+              },
+              behavior: HitTestBehavior.opaque,
+              child: SizedBox(
+                width: 48.w,
+                height: 48.w,
+                child: Center(
+                  child: SvgPicture.asset(
+                    'assets/icons/icon_info.svg',
+                    width: 24.w,
+                    height: 24.w,
+                    colorFilter: ColorFilter.mode(
+                      _isDarkMode ? AppColors.black200 : AppColors.black800,
+                      BlendMode.srcIn,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ============================================================================
+  // 액션 버튼들
+  // ============================================================================
+
+  /// QR 버튼 (경찰: 스캔 / 도둑: 표시)
+  Widget _buildQrButton() {
+    return _pulseIfActive(
+      step: 1,
+      child: SvgIconButton(
+        assetPath: _isDarkMode
+            ? 'assets/icons/icon_qr_code.svg'
+            : 'assets/icons/icon_qr_scan.svg',
+        onPressed: () {
+          _tryAdvanceMission(1);
+          AppSnackbar.show(
+            context,
+            message: _isDarkMode
+                ? '내 수배 QR이 화면에 표시돼요. 경찰에게 보여주면 체포'
+                : '카메라가 켜지고 도둑의 QR을 스캔해 체포할 수 있어요',
+            isDarkMode: _isDarkMode,
+          );
+        },
+        containerSize: 48,
+        iconSize: 24,
+        iconColor: _isDarkMode ? AppColors.green : AppColors.blue,
+        backgroundColor: _isDarkMode ? AppColors.black : null,
+      ),
+    );
+  }
+
+  /// 미션 배너 — 상단 타이머 바 바로 아래에 표시.
+  /// 3개 미션 모두 완료되면 숨김.
+  Widget _buildMissionBanner() {
+    if (_missionStep >= 3) return const SizedBox.shrink();
+
+    const descriptions = [
+      '참가자 보기 버튼을 눌러보세요',
+      'QR 버튼을 눌러보세요',
+      '지도로 돌아가 보세요',
+    ];
+
+    final accentColor = _isDarkMode ? AppColors.green : AppColors.blue;
+    final bgColor =
+        _isDarkMode ? AppColors.black800 : AppColors.blue100;
+    final descColor = _isDarkMode ? AppColors.white : AppColors.black800;
+
+    return Container(
+      width: double.infinity,
+      padding: EdgeInsets.symmetric(
+        horizontal: AppSpacing.horizontal16,
+        vertical: AppSpacing.vertical8,
+      ),
+      color: bgColor,
+      child: Row(
+        children: [
+          Text(
+            '미션 ${_missionStep + 1}/3',
+            style: AppTextStyles.tag12Semibold.copyWith(color: accentColor),
+          ),
+          SizedBox(width: AppSpacing.horizontal8),
+          Expanded(
+            child: Text(
+              descriptions[_missionStep],
+              style: AppTextStyles.paragraph_14.copyWith(color: descColor),
+            ),
+          ),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: List.generate(3, (i) {
+              return Padding(
+                padding: EdgeInsets.only(left: 4.w),
+                child: Container(
+                  width: 6.w,
+                  height: 6.w,
+                  decoration: BoxDecoration(
+                    color: i < _missionStep ? accentColor : AppColors.black300,
+                    shape: BoxShape.circle,
+                  ),
+                ),
+              );
+            }),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 좌측 상단 뒤로가기 버튼
+  Widget _buildBackButton() {
+    return Padding(
+      padding: EdgeInsets.only(left: AppSpacing.horizontal4),
+      child: IconButton(
+        icon: SvgPicture.asset(
+          'assets/icons/icon_previous.svg',
+          width: 24.w,
+          height: 24.w,
+          colorFilter: ColorFilter.mode(
+            _isDarkMode ? AppColors.white : AppColors.black,
+            BlendMode.srcIn,
+          ),
+        ),
+        onPressed: () => context.pop(),
+      ),
+    );
+  }
+
+  /// 팀 시점 토글 (튜토리얼 전용 — 경찰/도둑 시점 미리보기)
+  ///
+  /// 가독성을 위해 지도 placeholder 중앙에 배치.
+  Widget _buildTeamToggle() {
+    return GestureDetector(
+      onTap: () => setState(() => _isDarkMode = !_isDarkMode),
+      child: Container(
+        padding: EdgeInsets.symmetric(
+          horizontal: AppSpacing.horizontal16,
+          vertical: AppSpacing.vertical8,
+        ),
+        decoration: BoxDecoration(
+          color: _isDarkMode ? AppColors.black900 : AppColors.white,
+          borderRadius: AppRadius.xlarge,
+          border: Border.all(
+            color: _isDarkMode ? AppColors.black700 : AppColors.black200,
+            width: 1,
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            SvgPicture.asset(
+              'assets/icons/icon_change.svg',
+              width: 16.w,
+              height: 16.w,
+              colorFilter: ColorFilter.mode(
+                _isDarkMode ? AppColors.green : AppColors.blue,
+                BlendMode.srcIn,
+              ),
+            ),
+            SizedBox(width: AppSpacing.horizontal6),
+            Text(
+              _isDarkMode ? '도둑 시점 보는 중' : '경찰 시점 보는 중',
+              style: AppTextStyles.tag12Semibold.copyWith(
+                color: _isDarkMode ? AppColors.white : AppColors.black,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // ============================================================================
+  // 참가자 목록 — 실제 ParticipantOverlay 구조 그대로 재현
+  // ============================================================================
+
+  /// 참가자 목록 — 실제 [TeamSection] + [ParticipantCard] 재사용
+  ///
+  /// 데이터는 정적 fixture, 의존성 0 (TeamSection은 stateless 순수 위젯).
+  Widget _buildParticipantsList() {
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          TeamSection(
+            team: 'POLICE',
+            members: _demoPolice,
+            isExpanded: _isPoliceExpanded,
+            onToggle: () =>
+                setState(() => _isPoliceExpanded = !_isPoliceExpanded),
+            hostParticipantId: _demoHostParticipantId,
+            myParticipantId: _demoMyParticipantId,
+            badge: const SizedBox.shrink(),
+            isDarkMode: _isDarkMode,
+            gameStatusByParticipantId: _demoGameStatus,
+          ),
+          Divider(
+            height: 1,
+            color: _isDarkMode ? AppColors.black800 : AppColors.black200,
+          ),
+          TeamSection(
+            team: 'ROBBER',
+            members: _demoRobbers,
+            isExpanded: _isRobberExpanded,
+            onToggle: () =>
+                setState(() => _isRobberExpanded = !_isRobberExpanded),
+            hostParticipantId: _demoHostParticipantId,
+            myParticipantId: _demoMyParticipantId,
+            badge: _buildRobberBadge(2),
+            onMemberTap: (member) {
+              // 튜토리얼: 카드 탭 시 안내 스낵바 (실제는 체포/탈옥 모달)
+              if (_isDarkMode) {
+                AppSnackbar.show(
+                  context,
+                  message: '본인이 수감됐다면 카드 탭으로 탈옥을 시도할 수 있어요',
+                  isDarkMode: true,
+                );
+              } else {
+                AppSnackbar.show(
+                  context,
+                  message: '실제 게임에서는 QR 스캔으로 도둑을 체포해요',
+                  isDarkMode: false,
+                );
+              }
+            },
+            isDarkMode: _isDarkMode,
+            gameStatusByParticipantId: _demoGameStatus,
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 도둑팀 헤더 배지 (실제 [ParticipantOverlay._buildRobberBadge]와 동일)
+  Widget _buildRobberBadge(int count) {
+    final badgeColor = _isDarkMode ? AppColors.green800 : AppColors.blue800;
+    final badgeBoldColor = _isDarkMode ? AppColors.green : AppColors.blue;
+    return RichText(
+      text: TextSpan(
+        style: AppTextStyles.tag_12.copyWith(color: badgeColor),
+        children: [
+          const TextSpan(text: '현재 '),
+          TextSpan(
+            text: '$count명',
+            style: AppTextStyles.tag_12.copyWith(
+              color: badgeBoldColor,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const TextSpan(text: ' 도주 중!'),
+        ],
+      ),
+    );
+  }
+
+  // ============================================================================
+  // 채팅 collapsed 시트 정밀 복제
+  // ============================================================================
+
+  /// 실제 [ChatOverlay] collapsed 외형을 픽셀 단위로 복제.
+  ///
+  /// 구조 (실제 sheet 내부 Column 그대로):
+  /// - 외곽: black100/black900, 상단 xl20 라운드, shadow offset(0,-2) blur 10
+  /// - 28h 드래그 핸들 (48×4 indicator)
+  /// - **8h gap** (실제는 `Expanded(SizedBox.shrink)` — collapsed에서 8h 차지)
+  /// - [ChatInputBar] 외형 복제 (8 + 48 + 8 = 64h)
+  /// - 12h spacer
+  /// - 시스템 네비 inset (viewPadding.bottom or 37h fallback)
+  /// 합 = 28 + 8 + 64 + 12 + bottom = 112 + bottom (= kChatOverlayCollapsedFixedHeight + bottom)
+  Widget _buildChatCollapsedReplica() {
+    final viewPaddingBottom = MediaQuery.of(context).viewPadding.bottom;
+    // chat_overlay.dart _fallbackBottomPadding = 37 (SafeArea 없는 기기 대비)
+    final safeBottom = viewPaddingBottom > 0 ? viewPaddingBottom : 37.h;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: _isDarkMode ? AppColors.black900 : AppColors.black100,
+        borderRadius: BorderRadius.only(
+          topLeft: AppRadius.xl20.topLeft,
+          topRight: AppRadius.xl20.topRight,
+        ),
+        boxShadow: [
+          BoxShadow(
+            offset: const Offset(0, -2),
+            blurRadius: 10,
+            color: _isDarkMode ? AppColors.black : AppColors.black200,
+          ),
+        ],
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _buildDragHandle(),
+          SizedBox(height: 8.h), // Expanded(SizedBox.shrink) 자리
+          _buildChatInputBarReplica(),
+          SizedBox(height: AppSpacing.vertical12),
+          SizedBox(height: safeBottom),
+        ],
+      ),
+    );
+  }
+
+  /// 드래그 핸들 (실제 [ChatOverlay._buildDragHandle]와 동일)
+  Widget _buildDragHandle() {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () {
+        AppSnackbar.show(
+          context,
+          message: '핸들을 위로 드래그하면 채팅이 펼쳐져요',
+          isDarkMode: _isDarkMode,
+        );
+      },
+      child: SizedBox(
+        height: 28.h,
+        child: Center(
+          child: Container(
+            width: 48.w,
+            height: 4.h,
+            decoration: BoxDecoration(
+              color: _isDarkMode ? AppColors.black600 : AppColors.black200,
+              borderRadius: BorderRadius.circular(2.r),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// [ChatInputBar] 외형 정밀 복제
+  Widget _buildChatInputBarReplica() {
+    return Container(
+      padding: EdgeInsets.symmetric(
+        horizontal: AppSpacing.horizontal20,
+        vertical: AppSpacing.vertical8,
+      ),
+      color: _isDarkMode ? AppColors.black900 : AppColors.black100,
+      child: GestureDetector(
+        onTap: () {
+          AppSnackbar.show(
+            context,
+            message: '여기에 메시지를 입력하면 팀/전체 채팅으로 보낼 수 있어요',
+            isDarkMode: _isDarkMode,
+          );
+        },
+        child: Container(
+          height: 48.h,
+          padding: EdgeInsets.only(
+            left: AppSpacing.horizontal20,
+            right: AppSpacing.horizontal12,
+          ),
+          decoration: BoxDecoration(
+            color: _isDarkMode ? AppColors.black : AppColors.white,
+            borderRadius: AppRadius.large,
+          ),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  '채팅을 입력하세요',
+                  style: AppTextStyles.label16Medium.copyWith(
+                    color: _isDarkMode
+                        ? AppColors.black200
+                        : AppColors.black400,
+                  ),
+                ),
+              ),
+              _buildSendButtonReplica(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// 전송 버튼 (32×32 원형, 텍스트 없으니 비활성 색상 사용)
+  Widget _buildSendButtonReplica() {
+    return Container(
+      width: 32.w,
+      height: 32.w,
+      decoration: BoxDecoration(
+        color: _isDarkMode ? AppColors.black900 : AppColors.black200,
+        shape: BoxShape.circle,
+      ),
+      child: Center(
+        child: Transform.rotate(
+          angle: -math.pi / 2,
+          child: SvgPicture.asset(
+            'assets/icons/icon_arrow.svg',
+            width: 20.w,
+            height: 20.w,
+            colorFilter: ColorFilter.mode(
+              _isDarkMode ? AppColors.black400 : AppColors.white,
+              BlendMode.srcIn,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// 지도 placeholder 격자 패턴 페인터
+class _MapGridPainter extends CustomPainter {
+  _MapGridPainter({required this.isDarkMode});
+
+  final bool isDarkMode;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final grid = Paint()
+      ..color = isDarkMode ? AppColors.black700 : AppColors.black200
+      ..strokeWidth = 1;
+
+    const double step = 40;
+    for (double x = 0; x < size.width; x += step) {
+      canvas.drawLine(Offset(x, 0), Offset(x, size.height), grid);
+    }
+    for (double y = 0; y < size.height; y += step) {
+      canvas.drawLine(Offset(0, y), Offset(size.width, y), grid);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _MapGridPainter oldDelegate) =>
+      oldDelegate.isDarkMode != isDarkMode;
+}

--- a/lib/features/tutorial/presentation/pages/tutorial_catalog_page.dart
+++ b/lib/features/tutorial/presentation/pages/tutorial_catalog_page.dart
@@ -16,7 +16,7 @@ class TutorialCatalogPage extends StatelessWidget {
   static const _items = <_TutorialCatalogItem>[
     _TutorialCatalogItem(
       title: '방 만들기',
-      subtitle: '운동장·감옥 설정과 슬라이더 조작',
+      subtitle: '플레이그라운드·감옥 설정과 슬라이더 조작',
       icon: Icons.add_box_outlined,
     ),
     _TutorialCatalogItem(
@@ -183,11 +183,7 @@ class _TutorialCatalogCard extends StatelessWidget {
             ),
             SizedBox(width: AppSpacing.horizontal8),
             if (item.isActive)
-              Icon(
-                Icons.chevron_right,
-                size: 24.w,
-                color: AppColors.black800,
-              )
+              Icon(Icons.chevron_right, size: 24.w, color: AppColors.black800)
             else
               Container(
                 padding: EdgeInsets.symmetric(

--- a/lib/features/tutorial/presentation/pages/tutorial_catalog_page.dart
+++ b/lib/features/tutorial/presentation/pages/tutorial_catalog_page.dart
@@ -1,0 +1,213 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/constants/app_colors.dart';
+import '../../../../core/constants/spacing_and_radius.dart';
+import '../../../../core/constants/text_styles.dart';
+
+/// 튜토리얼 카탈로그 페이지
+///
+/// 5개 항목을 카드 리스트로 노출. 현재는 인게임만 활성, 나머지는
+/// "준비 중" 배지로 비활성. 활성 카드 탭 시 해당 라우트로 push.
+class TutorialCatalogPage extends StatelessWidget {
+  const TutorialCatalogPage({super.key});
+
+  static const _items = <_TutorialCatalogItem>[
+    _TutorialCatalogItem(
+      title: '방 만들기',
+      subtitle: '운동장·감옥 설정과 슬라이더 조작',
+      icon: Icons.add_box_outlined,
+    ),
+    _TutorialCatalogItem(
+      title: '방 참여하기',
+      subtitle: '초대 코드 입력과 QR 스캔',
+      icon: Icons.qr_code_scanner_outlined,
+    ),
+    _TutorialCatalogItem(
+      title: '대기방',
+      subtitle: '팀 변경, 게임 설정, 준비 완료',
+      icon: Icons.groups_outlined,
+    ),
+    _TutorialCatalogItem(
+      title: '인게임',
+      subtitle: '타이머·지도·참가자·채팅·QR',
+      icon: Icons.map_outlined,
+      route: '/tutorial/in-game',
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.white,
+      body: SafeArea(
+        child: Stack(
+          children: [
+            Padding(
+              padding: EdgeInsets.symmetric(
+                horizontal: AppSpacing.horizontal20,
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  SizedBox(height: AppSpacing.vertical48),
+                  Text(
+                    '튜토리얼',
+                    style: AppTextStyles.heading_24.copyWith(
+                      color: AppColors.black,
+                    ),
+                  ),
+                  SizedBox(height: AppSpacing.vertical8),
+                  Text(
+                    '게임을 처음 한다면 한 번씩 보고 시작해보세요',
+                    style: AppTextStyles.paragraph_14.copyWith(
+                      color: AppColors.black600,
+                    ),
+                  ),
+                  SizedBox(height: AppSpacing.vertical24),
+                  Expanded(
+                    child: ListView.separated(
+                      itemCount: _items.length,
+                      separatorBuilder: (_, _) =>
+                          SizedBox(height: AppSpacing.vertical12),
+                      itemBuilder: (_, i) =>
+                          _TutorialCatalogCard(item: _items[i]),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Positioned(
+              top: 0,
+              left: AppSpacing.horizontal4,
+              child: IconButton(
+                icon: Icon(
+                  Icons.arrow_back,
+                  color: AppColors.black,
+                  size: 24.w,
+                ),
+                onPressed: () => context.pop(),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TutorialCatalogItem {
+  const _TutorialCatalogItem({
+    required this.title,
+    required this.subtitle,
+    required this.icon,
+    this.route,
+  });
+
+  final String title;
+  final String subtitle;
+  final IconData icon;
+  final String? route;
+
+  bool get isActive => route != null;
+}
+
+class _TutorialCatalogCard extends StatelessWidget {
+  const _TutorialCatalogCard({required this.item});
+
+  final _TutorialCatalogItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: item.isActive ? () => context.push(item.route!) : null,
+      child: Container(
+        padding: EdgeInsets.symmetric(
+          horizontal: AppSpacing.horizontal16,
+          vertical: AppSpacing.vertical16,
+        ),
+        decoration: BoxDecoration(
+          color: item.isActive ? AppColors.white : AppColors.black100,
+          borderRadius: AppRadius.xl20,
+          boxShadow: item.isActive
+              ? [
+                  BoxShadow(
+                    offset: const Offset(0, 1),
+                    blurRadius: 4,
+                    color: AppColors.black100,
+                  ),
+                ]
+              : null,
+        ),
+        child: Row(
+          children: [
+            Container(
+              width: 48.w,
+              height: 48.w,
+              decoration: BoxDecoration(
+                color: item.isActive ? AppColors.blue100 : AppColors.black200,
+                borderRadius: AppRadius.large,
+              ),
+              child: Icon(
+                item.icon,
+                size: 24.w,
+                color: item.isActive ? AppColors.blue : AppColors.black400,
+              ),
+            ),
+            SizedBox(width: AppSpacing.horizontal12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    item.title,
+                    style: AppTextStyles.label_16.copyWith(
+                      color: item.isActive
+                          ? AppColors.black
+                          : AppColors.black500,
+                    ),
+                  ),
+                  SizedBox(height: AppSpacing.vertical4),
+                  Text(
+                    item.subtitle,
+                    style: AppTextStyles.tag_12.copyWith(
+                      color: item.isActive
+                          ? AppColors.black600
+                          : AppColors.black400,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            SizedBox(width: AppSpacing.horizontal8),
+            if (item.isActive)
+              Icon(
+                Icons.chevron_right,
+                size: 24.w,
+                color: AppColors.black800,
+              )
+            else
+              Container(
+                padding: EdgeInsets.symmetric(
+                  horizontal: AppSpacing.horizontal8,
+                  vertical: 4.h,
+                ),
+                decoration: BoxDecoration(
+                  color: AppColors.black200,
+                  borderRadius: AppRadius.medium,
+                ),
+                child: Text(
+                  '준비 중',
+                  style: AppTextStyles.tag_12.copyWith(
+                    color: AppColors.black500,
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/tutorial/presentation/styles/app_tutorial_style.dart
+++ b/lib/features/tutorial/presentation/styles/app_tutorial_style.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:tutorial_coach_mark/tutorial_coach_mark.dart';
+
+import '../../../../core/constants/app_colors.dart';
+import '../../../../core/constants/text_styles.dart';
+
+/// 텍스트 정렬 위치 (패키지 타입 캡슐화)
+enum TutorialAlign { top, bottom, left, right }
+
+/// 하이라이트 형태 (패키지 타입 캡슐화)
+enum TutorialShape { circle, roundedRect }
+
+/// 튜토리얼 코치마크 공통 스타일 및 헬퍼
+///
+/// tutorial_coach_mark 패키지 의존성을 이 파일에 격리하여
+/// 페이지에서 패키지를 직접 import하지 않도록 한다.
+class AppTutorialStyle {
+  AppTutorialStyle._();
+
+  /// 튜토리얼 타겟 정의 (패키지 타입을 노출하지 않는 래퍼)
+  static TutorialTarget target({
+    required GlobalKey keyTarget,
+    required String description,
+    TutorialAlign align = TutorialAlign.bottom,
+    TutorialShape shape = TutorialShape.roundedRect,
+    EdgeInsets? padding,
+  }) {
+    return TutorialTarget(
+      keyTarget: keyTarget,
+      description: description,
+      align: align,
+      shape: shape,
+      padding: padding,
+    );
+  }
+
+  /// 튜토리얼 표시
+  ///
+  /// [context] — BuildContext
+  /// [targets] — target()으로 생성한 목록
+  /// [onFinish] — 완료 콜백
+  ///
+  /// 반환된 [AppTutorialController]로 진행 중 타겟 위치 재계산(`refresh()`)이
+  /// 가능하다. 하위 호환을 위해 반환값 무시해도 동작은 그대로.
+  static AppTutorialController show({
+    required BuildContext context,
+    required List<TutorialTarget> targets,
+    VoidCallback? onFinish,
+  }) {
+    final focusTargets = targets.map((t) => t._toTargetFocus()).toList();
+
+    final coach = TutorialCoachMark(
+      targets: focusTargets,
+      colorShadow: AppColors.black,
+      opacityShadow: 0.8,
+      hideSkip: true,
+      onFinish: onFinish,
+    );
+    coach.show(context: context);
+    return AppTutorialController._(coach);
+  }
+}
+
+/// 표시 중인 튜토리얼을 제어하는 핸들
+///
+/// 패키지의 `TutorialCoachMark`를 캡슐화하여 상위 코드가 직접 의존하지
+/// 않도록 한다. 레이아웃이 변한 시점에 `refresh()`를 호출하면 현재
+/// 활성화된 타겟의 화면 좌표를 다시 계산한다.
+class AppTutorialController {
+  AppTutorialController._(this._coach);
+
+  final TutorialCoachMark _coach;
+
+  /// 튜토리얼 오버레이가 떠 있는지 여부
+  bool get isShowing => _coach.isShowing;
+
+  /// 현재 타겟 위치 재계산
+  ///
+  /// 패키지가 `refreshTargetPosition()`을 외부로 직접 노출하지 않기 때문에,
+  /// 내부의 `didChangeMetrics` 경로를 빌려 좌표를 강제 재계산한다.
+  /// (패키지 내부에서 `didChangeMetrics`가 `refreshTargetPosition()`을 호출)
+  ///
+  /// 레이아웃이 실제로 변하지 않은 위젯은 `handleMetricsChanged`로 인한
+  /// 리빌드가 발생해도 대부분 no-op이므로 성능 영향은 미미하다.
+  void refresh() {
+    if (!_coach.isShowing) return;
+    WidgetsBinding.instance.handleMetricsChanged();
+  }
+
+  /// 튜토리얼 강제 종료
+  void finish() => _coach.finish();
+}
+
+/// 패키지 타입을 숨기는 내부 래퍼
+class TutorialTarget {
+  const TutorialTarget({
+    required this.keyTarget,
+    required this.description,
+    required this.align,
+    required this.shape,
+    this.padding,
+  });
+
+  final GlobalKey keyTarget;
+  final String description;
+  final TutorialAlign align;
+  final TutorialShape shape;
+  final EdgeInsets? padding;
+
+  TargetFocus _toTargetFocus() {
+    return TargetFocus(
+      keyTarget: keyTarget,
+      alignSkip: Alignment.topRight,
+      shape: _mapShape(shape),
+      radius: 8,
+      contents: [
+        TargetContent(
+          align: _mapAlign(align),
+          builder: (context, controller) {
+            return Padding(
+              padding:
+                  padding ??
+                  const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+              child: Text(
+                description,
+                style: AppTextStyles.paragraph_14.copyWith(
+                  color: AppColors.white,
+                ),
+              ),
+            );
+          },
+        ),
+      ],
+    );
+  }
+
+  static ContentAlign _mapAlign(TutorialAlign align) => switch (align) {
+    TutorialAlign.top => ContentAlign.top,
+    TutorialAlign.bottom => ContentAlign.bottom,
+    TutorialAlign.left => ContentAlign.left,
+    TutorialAlign.right => ContentAlign.right,
+  };
+
+  static ShapeLightFocus _mapShape(TutorialShape shape) => switch (shape) {
+    TutorialShape.circle => ShapeLightFocus.Circle,
+    TutorialShape.roundedRect => ShapeLightFocus.RRect,
+  };
+}

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -31,6 +31,8 @@ import '../features/session/data/models/game_settings_response.dart';
 import '../features/game/presentation/pages/game_page.dart';
 import '../features/notice/presentation/pages/notices_page.dart';
 import '../features/settings/presentation/pages/settings_page.dart';
+import '../features/tutorial/presentation/pages/in_game_tutorial_page.dart';
+import '../features/tutorial/presentation/pages/tutorial_catalog_page.dart';
 import '../features/credits/presentation/pages/credits_page.dart';
 import '../features/lifecycle_test/presentation/pages/lifecycle_test_page.dart';
 import '../core/widgets/pages/maintenance_page.dart';
@@ -230,6 +232,26 @@ final routerProvider = Provider<GoRouter>((ref) {
         name: RoutePaths.agreementName,
         pageBuilder: (context, state) =>
             buildSmoothFade(key: state.pageKey, child: const AgreementPage()),
+      ),
+
+      // ====================================================================
+      // Tutorial Routes (튜토리얼 — 카탈로그 + 항목별 디테일)
+      // ====================================================================
+      GoRoute(
+        path: '/tutorial',
+        pageBuilder: (context, state) => buildDirectionalSlide(
+          key: state.pageKey,
+          child: const TutorialCatalogPage(),
+          isForward: true,
+        ),
+      ),
+      GoRoute(
+        path: '/tutorial/in-game',
+        pageBuilder: (context, state) => buildDirectionalSlide(
+          key: state.pageKey,
+          child: const InGameTutorialPage(),
+          isForward: true,
+        ),
       ),
 
       // ====================================================================

--- a/test/core/services/tutorial/tutorial_keys_test.dart
+++ b/test/core/services/tutorial/tutorial_keys_test.dart
@@ -11,4 +11,14 @@ void main() {
       expect(TutorialKeys.all, contains(TutorialKeys.waitingRoom));
     });
   });
+
+  group('TutorialKeys.inGamePrompt', () {
+    test('단일 키 상수 값', () {
+      expect(TutorialKeys.inGamePrompt, 'tutorial_in_game_prompt');
+    });
+
+    test('TutorialKeys.all 에 포함된다', () {
+      expect(TutorialKeys.all, contains(TutorialKeys.inGamePrompt));
+    });
+  });
 }

--- a/test/features/tutorial/presentation/pages/tutorial_catalog_page_test.dart
+++ b/test/features/tutorial/presentation/pages/tutorial_catalog_page_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:cops_and_robbers/features/tutorial/presentation/pages/tutorial_catalog_page.dart';
+
+GoRouter _testRouter() {
+  return GoRouter(
+    initialLocation: '/tutorial',
+    routes: [
+      GoRoute(
+        path: '/tutorial',
+        builder: (_, _) => const TutorialCatalogPage(),
+      ),
+      GoRoute(
+        path: '/tutorial/in-game',
+        builder: (_, _) =>
+            const Scaffold(body: Text('IN_GAME_LANDED')),
+      ),
+    ],
+  );
+}
+
+Widget _wrap(WidgetTester tester, GoRouter router) {
+  // iPhone X 크기로 설정 — overflow 방지 및 ScreenUtil 정확도 향상
+  tester.view.physicalSize = const Size(1125, 2436);
+  tester.view.devicePixelRatio = 3.0;
+
+  return ProviderScope(
+    child: ScreenUtilInit(
+      designSize: const Size(375, 812),
+      minTextAdapt: true,
+      splitScreenMode: true,
+      builder: (_, _) => MaterialApp.router(routerConfig: router),
+    ),
+  );
+}
+
+void main() {
+  group('TutorialCatalogPage', () {
+    testWidgets('renders_4_cards_with_titles_when_built', (tester) async {
+      await tester.pumpWidget(_wrap(tester, _testRouter()));
+      await tester.pumpAndSettle();
+
+      expect(find.text('방 만들기'), findsOneWidget);
+      expect(find.text('방 참여하기'), findsOneWidget);
+      expect(find.text('대기방'), findsOneWidget);
+      expect(find.text('인게임'), findsOneWidget);
+      expect(find.text('QR 체포·탈옥'), findsNothing);
+    });
+
+    testWidgets(
+      'shows_준비_중_badge_for_3_disabled_cards_when_built',
+      (tester) async {
+        await tester.pumpWidget(_wrap(tester, _testRouter()));
+        await tester.pumpAndSettle();
+
+        expect(find.text('준비 중'), findsNWidgets(3));
+      },
+    );
+
+    testWidgets(
+      'inGame_card_navigates_to_in_game_route_when_tapped',
+      (tester) async {
+        await tester.pumpWidget(_wrap(tester, _testRouter()));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('인게임'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('IN_GAME_LANDED'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'disabled_card_does_not_navigate_when_tapped',
+      (tester) async {
+        await tester.pumpWidget(_wrap(tester, _testRouter()));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('방 만들기'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('IN_GAME_LANDED'), findsNothing);
+        expect(find.text('방 만들기'), findsOneWidget);
+      },
+    );
+  });
+}

--- a/test/features/tutorial/presentation/pages/tutorial_catalog_page_test.dart
+++ b/test/features/tutorial/presentation/pages/tutorial_catalog_page_test.dart
@@ -16,8 +16,7 @@ GoRouter _testRouter() {
       ),
       GoRoute(
         path: '/tutorial/in-game',
-        builder: (_, _) =>
-            const Scaffold(body: Text('IN_GAME_LANDED')),
+        builder: (_, _) => const Scaffold(body: Text('IN_GAME_LANDED')),
       ),
     ],
   );
@@ -51,41 +50,36 @@ void main() {
       expect(find.text('QR 체포·탈옥'), findsNothing);
     });
 
-    testWidgets(
-      'shows_준비_중_badge_for_3_disabled_cards_when_built',
-      (tester) async {
-        await tester.pumpWidget(_wrap(tester, _testRouter()));
-        await tester.pumpAndSettle();
+    testWidgets('shows_준비_중_badge_for_3_disabled_cards_when_built', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_wrap(tester, _testRouter()));
+      await tester.pumpAndSettle();
 
-        expect(find.text('준비 중'), findsNWidgets(3));
-      },
-    );
+      expect(find.text('준비 중'), findsNWidgets(3));
+    });
 
-    testWidgets(
-      'inGame_card_navigates_to_in_game_route_when_tapped',
-      (tester) async {
-        await tester.pumpWidget(_wrap(tester, _testRouter()));
-        await tester.pumpAndSettle();
+    testWidgets('inGame_card_navigates_to_in_game_route_when_tapped', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_wrap(tester, _testRouter()));
+      await tester.pumpAndSettle();
 
-        await tester.tap(find.text('인게임'));
-        await tester.pumpAndSettle();
+      await tester.tap(find.text('인게임'));
+      await tester.pumpAndSettle();
 
-        expect(find.text('IN_GAME_LANDED'), findsOneWidget);
-      },
-    );
+      expect(find.text('IN_GAME_LANDED'), findsOneWidget);
+    });
 
-    testWidgets(
-      'disabled_card_does_not_navigate_when_tapped',
-      (tester) async {
-        await tester.pumpWidget(_wrap(tester, _testRouter()));
-        await tester.pumpAndSettle();
+    testWidgets('disabled_card_does_not_navigate_when_tapped', (tester) async {
+      await tester.pumpWidget(_wrap(tester, _testRouter()));
+      await tester.pumpAndSettle();
 
-        await tester.tap(find.text('방 만들기'));
-        await tester.pumpAndSettle();
+      await tester.tap(find.text('방 만들기'));
+      await tester.pumpAndSettle();
 
-        expect(find.text('IN_GAME_LANDED'), findsNothing);
-        expect(find.text('방 만들기'), findsOneWidget);
-      },
-    );
+      expect(find.text('IN_GAME_LANDED'), findsNothing);
+      expect(find.text('방 만들기'), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
# feat : 튜토리얼 카탈로그 + 인게임 튜토리얼 페이지 신설 #336

---

## Summary

기존 인게임 화면 위에 떠 있던 코치마크 오버레이를 제거하고, 실제 게임 화면을 본떠 만든 별도의 "인게임 튜토리얼 페이지"로 분리한다. 신규 사용자에게는 대기방 코치마크 종료 후 1회 자동 다이얼로그로 강제 노출하고, 이후에는 설정 메뉴와 게임 규칙 다이얼로그를 통해 언제든지 재방문할 수 있게 한다.

## Changes

- `lib/features/tutorial/presentation/pages/in_game_tutorial_page.dart` 신설 — 실제 `GamePage` 레이아웃(HUD, 미니맵, 액션 버튼 등)을 정적 미리보기로 재구성. 지도는 격자 placeholder, 타이머/위치 공개 카운트다운은 외형만 복제한 정적 텍스트, STOMP·Riverpod 의존성 0
- `lib/features/tutorial/presentation/pages/tutorial_catalog_page.dart` 신설 — 설정에서 진입하는 튜토리얼 카탈로그 페이지
- `lib/features/tutorial/presentation/styles/app_tutorial_style.dart` 신설 — 튜토리얼 화면 공통 스타일 상수
- `lib/features/game/presentation/pages/game_page.dart` — 인게임에 박혀 있던 코치마크 오버레이/키 제거, GamePage는 순수 게임 화면으로 환원
- `lib/features/session/presentation/pages/waiting_room_page.dart` — 대기방 코치마크 완료 시점에 `tutorial_in_game_prompt` SharedPreferences 키로 1회 다이얼로그 노출 로직 추가
- `lib/features/session/presentation/widgets/game_rules_content.dart` — 게임 규칙 다이얼로그(앱바 ⓘ)에 "인게임 보기" primary 버튼 추가
- `lib/features/settings/presentation/pages/settings_page.dart` — 설정 메뉴에 "튜토리얼 다시 보기" 항목 추가, 튜토리얼 초기화 시 `tutorial_in_game_prompt` 함께 리셋
- `lib/features/session/presentation/pages/session_creation_flow_page.dart`, `step_2_game_settings_content.dart` — 게임 설정 코치마크 키 3개(라운드/위치/경찰)를 `settingsKey` 1개로 통합
- `lib/core/services/tutorial/tutorial_keys.dart` — 인게임 코치마크 키 제거, 자동 노출 SharedPreferences 키 상수 추가
- `lib/router/app_router.dart` — 튜토리얼 카탈로그/인게임 튜토리얼 라우트 등록
- `test/core/services/tutorial/tutorial_keys_test.dart`, `test/features/tutorial/presentation/pages/tutorial_catalog_page_test.dart` — 키 상수·카탈로그 페이지 테스트 추가

## Behavior Change

| 항목 | Before | After |
|---|---|---|
| 인게임 튜토리얼 표시 위치 | 실제 GamePage 위 코치마크 오버레이 | 별도의 인게임 튜토리얼 페이지(정적 미리보기) |
| 신규 사용자 자동 노출 | 게임 시작 직후 코치마크 자동 실행 | 대기방 코치마크 완료 직후 다이얼로그로 안내, 동의 시 인게임 튜토리얼 페이지로 이동 (1회) |
| 재방문 진입점 | 없음 (한 번 보면 끝) | 설정 → 튜토리얼 다시 보기 / 게임 규칙 다이얼로그의 "인게임 보기" |
| 튜토리얼 초기화 | 코치마크 1회 노출 플래그만 리셋 | 코치마크 플래그 + `tutorial_in_game_prompt` 함께 리셋 |
| 게임 설정 코치마크 키 | 라운드/위치/경찰 슬라이더 각 1개씩 3개 | 동일 UI 3개를 `settingsKey` 1개로 통합 |
| 인게임 타이머 | `GameTimerText` / `LocationRevealCountdown` 위젯이 매초 setState로 재빌드 | 외형만 복제한 정적 텍스트(`29:30`, `다음 도둑 위치 공개까지 04:30`) |
| 게임 화면 코드 | 코치마크 GlobalKey·오버레이·트리거 로직 포함 | 코치마크 의존성 제거, 순수 게임 화면 |

## Test Plan

- [ ] `flutter analyze` 통과
- [ ] `flutter test` 통과 (튜토리얼 키 / 카탈로그 페이지 테스트 포함)
- [ ] 신규 사용자 시나리오: 대기방 코치마크 완료 → 자동 다이얼로그 노출 → 동의 시 인게임 튜토리얼 페이지 진입 → 다시 대기방으로 돌아왔을 때 다이얼로그 재노출되지 않음
- [ ] 자동 노출 1회 보장: 앱 재시작/대기방 재입장 시 동일 사용자에게 다이얼로그가 다시 뜨지 않음
- [ ] 재진입: 설정 → 튜토리얼 다시 보기 → 카탈로그 → 인게임 튜토리얼 페이지 진입 가능
- [ ] 재진입: 게임 진행 중 앱바 ⓘ → 게임 규칙 다이얼로그 → "인게임 보기" 버튼으로 인게임 튜토리얼 페이지 진입 가능
- [ ] 튜토리얼 초기화: 설정에서 초기화 후 신규 사용자처럼 대기방 코치마크 + 다이얼로그가 다시 노출됨
- [ ] 인게임 튜토리얼 페이지 단독 동작: 실제 GamePage 진입 없이도 STOMP/위치권한 요구 없이 렌더링됨
- [ ] 인게임 튜토리얼 페이지의 타이머/위치 공개 카운트다운이 정적 텍스트로 표시되고 매초 재빌드되지 않음
- [ ] 게임 설정 코치마크: 통합된 `settingsKey` 1개로 3개 슬라이더 영역을 한 번에 안내함
- [ ] 인게임 화면(`GamePage`) 진입 시 코치마크 오버레이가 더 이상 뜨지 않음

## Notes

- 자동 노출 1회 보장 키: `SharedPreferences`의 `tutorial_in_game_prompt`. "튜토리얼 초기화" 시 함께 리셋되도록 연결
- 인게임 튜토리얼 페이지는 의도적으로 정적 미리보기 — 타이머/위치 공개 카운트다운도 매초 setState 하지 않고 외형(스타일/문구 위치)만 복제한 정적 텍스트로 표시. 값은 고정(`29:30`, `04:30`)
- 게임 설정 코치마크 키 통합은 동일한 슬라이더 UI 3개에 같은 안내가 3번 떠 사용자 경험이 반복적이었던 문제 해결 목적
- 설계 및 구현 계획서: `docs/superpowers/specs/2026-05-11-in-game-tutorial-entry-point-design.md`, `docs/superpowers/plans/2026-05-11-in-game-tutorial-entry-point.md`

Closes #336


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 인게임 튜토리얼 추가: 대기방 튜토리얼 완료 후 자동으로 표시되는 한 번의 인게임 튜토리얼 프롬프트
  * 튜토리얼 카탈로그 페이지: 이용 가능한 튜토리얼을 한눈에 확인하는 새로운 메뉴
  * 튜토리얼 초기화 기능: 설정에서 "튜토리얼 다시 보기" 옵션으로 튜토리얼 초기화 가능

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cops-and-robbers/cops-and-robbers-FE/pull/341)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->