### PR TITLE
fix : 앱 재시작 후 체포 상태 ArrestLockOverlay 복원 #344

### DIFF
--- a/lib/features/game/presentation/pages/game_page.dart
+++ b/lib/features/game/presentation/pages/game_page.dart
@@ -1296,20 +1296,19 @@ class _GamePageState extends ConsumerState<GamePage>
     // 도둑팀 경찰 시작 카운트다운용 시각 계산
     final policeStartTime = _computePoliceStartTime();
 
-    // 재연결 감지 → 도둑 팀 위치 즉시 재전송 + 재연결 모달 표시/닫기
+    // 연결 성공 시 게임 상태 동기화 + 도둑 팀 위치 즉시 재전송 / 끊김 시 재연결 모달 처리
     ref.listen(gameEventNotifierProvider.select((s) => s.connectionState), (
       prev,
       next,
     ) {
-      // 재연결 성공 → 게임 상태 동기화 + 도둑 팀 위치 즉시 재전송
+      // 연결 성공 → 게임 상태 동기화 + 도둑 팀 위치 즉시 재전송
       if (next == StompConnectionState.connected &&
           prev != StompConnectionState.connected) {
-        // 끊김 구간 동안 누락된 체포·탈옥 이벤트를 서버 조회로 보정.
+        // 끊김 구간 + 앱 재시작 후 첫 진입에서 누락된 체포·탈옥 상태를 서버 조회로 보정.
+        // 최초 connected에서도 호출해, 재실행 시 JAILED 상태가 ArrestLockOverlay에 반영되도록 한다.
         // 의도적으로 await하지 않음 — 아래 도둑 팀 위치 즉시 재전송이
         // HTTP 응답을 기다리다 지연되지 않도록. 에러는 메서드 내부 try-catch에서 처리.
-        if (_hasGameEventConnectedOnce) {
-          unawaited(_syncGameStateOnReconnect());
-        }
+        unawaited(_syncGameStateOnReconnect());
 
         if (widget.team == 'ROBBER' && !widget.isDummy) {
           if (_lastSentPosition != null) {

--- a/lib/features/game/presentation/widgets/arrest_lock_overlay.dart
+++ b/lib/features/game/presentation/widgets/arrest_lock_overlay.dart
@@ -77,7 +77,7 @@ class ArrestLockOverlay extends ConsumerWidget {
                         Text(
                           '체포되어 있는 동안에는 게임 상황을 확인할 수 없어요\n같은 팀에게 구조 요청을 하며 빠르게 탈옥해요!',
                           style: AppTextStyles.paragraph_14.copyWith(
-                            color: AppColors.black300,
+                            color: AppColors.black400,
                           ),
                           textAlign: TextAlign.center,
                         ),


### PR DESCRIPTION
# fix : 앱 재시작 후 체포 상태 ArrestLockOverlay 복원 #344

---

## Summary

도둑이 체포(JAILED)된 상태에서 앱을 강제 종료한 뒤 다시 실행하면 `ArrestLockOverlay`가 표시되지 않던 #344 이슈를 수정한다. STOMP `connected` 핸들러의 `_hasGameEventConnectedOnce` 가드 때문에 앱 재시작 후 최초 연결에서 서버 상태 동기화(`_syncGameStateOnReconnect()`)가 건너뛰어지던 것이 원인이었다.

## Changes

- `lib/features/game/presentation/pages/game_page.dart`: STOMP `connected` 리스너에서 `_syncGameStateOnReconnect()` 호출의 `_hasGameEventConnectedOnce` 가드 제거. 주석을 "재연결" 기준에서 "최초 연결 포함" 기준으로 갱신
- `lib/features/game/presentation/widgets/arrest_lock_overlay.dart`: 모달 본문 텍스트 색상을 `AppColors.black300` → `AppColors.black400`으로 톤 조정

## Behavior Change

```dart
// Before — _hasGameEventConnectedOnce 가드로 최초 연결에서는 sync 미호출
if (next == StompConnectionState.connected &&
    prev != StompConnectionState.connected) {
  if (_hasGameEventConnectedOnce) {
    unawaited(_syncGameStateOnReconnect());
  }
  // ... 도둑 팀 위치 즉시 재전송
}

// After — 최초 연결에서도 sync 호출 (앱 재시작 시 서버 상태로 복원)
if (next == StompConnectionState.connected &&
    prev != StompConnectionState.connected) {
  unawaited(_syncGameStateOnReconnect());
  // ... 도둑 팀 위치 즉시 재전송
}
```

| 항목 | Before | After |
|---|---|---|
| 체포 상태에서 앱 강제 종료 후 재실행 | `ArrestLockOverlay` 미표시 (체포 도둑이 지도/AppBar/우측 버튼 사용 가능) | 최초 STOMP 연결 시 서버 참가자 상태 조회 → 본인 ID가 `arrestedParticipantIds`에 포함 → 오버레이 정상 표시 |
| 정상 게임 시작 시 최초 연결 | sync 미호출 | sync 호출되지만 서버에 JAILED 없음 → 상태 변화 없음 |
| 진행 중 STOMP 끊김 → 자동 재연결 | sync 호출 | 동일 (변경 없음) |
| `_syncGameStateOnReconnect()` 내부 race-condition 보정 로직 | 끊김 직전/직후 snapshot 비교 후 STOMP delta 보존 | 동일 (최초 연결에서도 동일 로직 적용되어 안전) |
| 재연결 모달(`_showReconnectModalIfNeeded`) 노출 가드 | `_hasGameEventConnectedOnce` 사용 | 동일 (변경 없음 — sync 호출 가드만 제거) |

## Test Plan

- [x] `flutter analyze` clean
- [x] `flutter test test/features/game` 44개 PASS
- [ ] 시나리오 1 — 정상 게임 시작 → 최초 connected: sync 호출되지만 상태 변화 없음, 오버레이 미표시
- [ ] 시나리오 2 — 본인 체포 상태에서 앱 강제 종료 → 재실행 → GamePage 진입: 최초 connected에서 sync → `ArrestLockOverlay` 표시
- [ ] 시나리오 3 — 진행 중 STOMP 끊김 → 자동 재연결: sync 호출, 기존 동작 유지
- [ ] 시나리오 4 — 본인 탈옥 후 앱 재시작: 서버 status `ALIVE` → 오버레이 미표시
- [ ] 시나리오 5 — 다른 도둑이 체포된 상태에서 본인 재시작: 본인 오버레이는 미표시, 참가자 카드 UI는 JAILED로 표시
- [ ] 시나리오 6 — 경찰 팀으로 재시작: `widget.team == 'ROBBER'` 조건 false → 오버레이 미표시
- [ ] 시나리오 7 — sync HTTP 실패: 예외 삼킴 후 로그만, 후속 STOMP 이벤트 또는 다음 재연결 시점 sync에서 복원

## Notes

- 설계 문서: `docs/superpowers/specs/2026-05-12-arrest-overlay-restart-restore-design.md`
- 실행 플랜: `docs/superpowers/plans/2026-05-12-arrest-overlay-restart-restore.md`
- 원본 이슈: `.issues/20260512_버그_도둑체포_오버레이_앱재시작_미표시.md`
- `_hasGameEventConnectedOnce` 플래그 자체는 그대로 유지 — 재연결 모달(`_showReconnectModalIfNeeded`)을 "최초 연결 이후"에만 띄우는 가드로 계속 사용됨. 변경 범위는 sync 호출 한 줄에 한정
- 정상 게임 시작 시에도 `GET /api/games/{id}/participants` 1회가 추가되지만, 동일 provider를 `participant_overlay.dart`에서 이미 호출하고 있고 참가자 수 최대 30명이라 비용 부담 없음
- 비범위: 채팅 히스토리 복원, 위치 공개 타이머 복원, GAME_OVER 상태 복원, 로컬 영속화 — 동일한 "앱 재시작 복원" 주제이지만 별도 이슈로 다룸

Closes #344
