### PR TITLE
앱 설치명 다국어 지원 (ko/en/ja) : feat : 홈 화면 앱 이름 i18n 처리 #370

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,7 +30,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
 
     <application
-        android:label="경찰과도둑"
+        android:label="@string/app_name"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- 홈 화면 앱 이름 (일본어). ARB의 appBrandName과 일치 -->
+    <string name="app_name">ケイドロ</string>
+</resources>

--- a/android/app/src/main/res/values-ko/strings.xml
+++ b/android/app/src/main/res/values-ko/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- 홈 화면 앱 이름 (한국어) -->
+    <string name="app_name">경찰과도둑</string>
+</resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- 홈 화면 앱 이름 (default: 영어). 지원 외 OS 로케일에서 fallback으로 사용 -->
+    <string name="app_name">Cops and Robbers</string>
+</resources>

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		FF0185575ADAFFF54CF1235B /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 058107DD45658C40645C4884 /* Pods_Runner.framework */; };
+		A1B2C3D40000000000000020 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000010 /* InfoPlist.strings */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -68,6 +69,9 @@
 		AF9E9E55CAC8B376FEB15618 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		B0BEEED69C954906E95FC0DC /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		C59E8F12ECC9CE124FAD3416 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		A1B2C3D40000000000000001 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		A1B2C3D40000000000000002 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		A1B2C3D40000000000000003 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -148,6 +152,7 @@
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
 				97C147021CF9000F007C117D /* Info.plist */,
+				A1B2C3D40000000000000010 /* InfoPlist.strings */,
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
@@ -240,6 +245,8 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				ko,
+				ja,
 				Base,
 			);
 			mainGroup = 97C146E51CF9000F007C117D;
@@ -270,6 +277,7 @@
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
 				6274E3F78489D0283EDC9809 /* GoogleService-Info.plist in Resources */,
+				A1B2C3D40000000000000020 /* InfoPlist.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -430,6 +438,16 @@
 				97C147001CF9000F007C117D /* Base */,
 			);
 			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+		A1B2C3D40000000000000010 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				A1B2C3D40000000000000001 /* Base */,
+				A1B2C3D40000000000000002 /* ko */,
+				A1B2C3D40000000000000003 /* ja */,
+			);
+			name = InfoPlist.strings;
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */

--- a/ios/Runner/Base.lproj/InfoPlist.strings
+++ b/ios/Runner/Base.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+/* 홈 화면 앱 이름 (default: 영어). 지원 외 OS 로케일에서 fallback으로 사용 */
+"CFBundleDisplayName" = "Cops and Robbers";

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -7,13 +7,19 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>경찰과도둑</string>
+	<string>Cops and Robbers</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>en</string>
+		<string>ko</string>
+		<string>ja</string>
+	</array>
 	<key>CFBundleName</key>
 	<string>cops_and_robbers</string>
 	<key>CFBundlePackageType</key>

--- a/ios/Runner/ja.lproj/InfoPlist.strings
+++ b/ios/Runner/ja.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+/* 홈 화면 앱 이름 (일본어). ARB의 appBrandName과 일치 */
+"CFBundleDisplayName" = "ケイドロ";

--- a/ios/Runner/ko.lproj/InfoPlist.strings
+++ b/ios/Runner/ko.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+/* 홈 화면 앱 이름 (한국어) */
+"CFBundleDisplayName" = "경찰과도둑";


### PR DESCRIPTION
- Android: values/ values-ko/ values-ja/ strings.xml 추가 (default: Cops and Robbers, ko: 경찰과도둑, ja: ケイドロ)
- AndroidManifest의 android:label을 @string/app_name 참조로 변경
- iOS: Base.lproj/ ko.lproj/ ja.lproj/ InfoPlist.strings 추가 (CFBundleDisplayName 정의)
- iOS Info.plist에 CFBundleLocalizations 배열 추가, fallback을 Cops and Robbers로 변경
- Xcode project.pbxproj에 lproj 등록 (knownRegions, VariantGroup, BuildFile)

https://github.com/cops-and-robbers/cops-and-robbers-FE/issues/370

## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->


## ✅ 테스트
---

- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **다국어 지원 추가** - 앱이 한국어, 일본어, 영어로 현지화되었습니다. 사용자의 기기 언어 설정에 따라 앱 이름이 자동으로 표시됩니다.
* **플랫폼 확대** - Android 및 iOS 모두에서 멀티 로케일 지원이 구현되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cops-and-robbers/cops-and-robbers-FE/pull/371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->