### PR TITLE
feat : 약관 페이지 진입 시 서버 동의 상태 조회하여 체크박스 초기화 #373

### DIFF
--- a/lib/features/auth/presentation/pages/agreement_page.dart
+++ b/lib/features/auth/presentation/pages/agreement_page.dart
@@ -108,10 +108,15 @@ class AgreementPage extends ConsumerWidget {
                 ),
                 AppButton(
                   text: l10n.agreementPageAgreeButton,
-                  onPressed: state.hasAllRequired && !state.isSubmitting
+                  // 초기 로드 중에는 서버 응답이 사용자 입력을 덮어쓸 수 있어
+                  // 버튼을 잠시 비활성화한다.
+                  onPressed:
+                      state.hasAllRequired &&
+                          !state.isSubmitting &&
+                          !state.isLoading
                       ? () => _onSubmit(context, ref)
                       : null,
-                  isLoading: state.isSubmitting,
+                  isLoading: state.isLoading || state.isSubmitting,
                   showBorder: false,
                 ),
               ],

--- a/lib/features/auth/presentation/providers/agreement_provider.dart
+++ b/lib/features/auth/presentation/providers/agreement_provider.dart
@@ -26,7 +26,9 @@ enum AgreementSubmitResult {
 
 /// 약관 동의 화면 상태
 ///
-/// 4개 체크박스 + 제출 중 여부를 담는 불변 상태.
+/// 4개 체크박스 + 초기 로드/제출 중 여부를 담는 불변 상태.
+/// [isLoading]은 진입 직후 서버 동의 상태를 가져오는 동안 true이며,
+/// 이 사이 토글/제출이 응답 값을 덮어쓰지 않도록 가드 용도로 사용된다.
 @freezed
 class AgreementState with _$AgreementState {
   const factory AgreementState({
@@ -34,6 +36,7 @@ class AgreementState with _$AgreementState {
     @Default(false) bool privacyPolicy,
     @Default(false) bool locationTerms,
     @Default(false) bool marketing,
+    @Default(true) bool isLoading,
     @Default(false) bool isSubmitting,
   }) = _AgreementState;
 
@@ -51,40 +54,83 @@ class AgreementState with _$AgreementState {
 /// 체크박스 상태 관리 + `PUT /api/user/agreements` 제출을 담당합니다.
 /// 제출 성공 시 AuthNotifier의 requiresAgreement를 false로 갱신하는 책임은
 /// 호출자(AgreementPage)가 담당합니다 (Provider 간 강결합 회피).
+///
+/// [build] 진입 시 `GET /api/user/agreements`를 호출하여 서버에 저장된
+/// 현재 동의 상태로 체크박스를 초기화합니다. 백엔드가 정책 갱신으로 특정
+/// 약관만 false로 되돌리는 경우, 이미 동의한 약관은 체크된 상태로 표시되어
+/// 사용자가 변경된 약관만 새로 체크하면 되도록 합니다.
 @riverpod
 class AgreementNotifier extends _$AgreementNotifier {
   /// 마지막 submit 에러 (UI에서 스낵바 표시용)
   AppException? lastError;
 
   @override
-  AgreementState build() => const AgreementState();
+  AgreementState build() {
+    // dispose 이후 비동기 콜백이 state를 건드리면 Riverpod이 throw하므로,
+    // 명시적 플래그로 가드한다 (일반 Notifier에는 ref.mounted가 없음).
+    var disposed = false;
+    ref.onDispose(() => disposed = true);
 
-  // 제출 중에는 체크박스 변경을 무시한다.
-  // 서버 요청이 날아간 뒤 사용자가 토글하면 화면 표시값과 서버 저장값이 어긋나므로,
-  // 동의 이력의 정합성을 지키기 위해 토글·일괄설정 모두 가드한다.
+    // build()는 동기 유지, 초기 로드는 microtask로 미룬다.
+    // 첫 frame은 isLoading=true 상태로 그리고, 응답 도착 시 state를 갱신해
+    // 자연스러운 rebuild가 일어나도록 한다.
+    Future.microtask(() => _loadInitial(isDisposed: () => disposed));
+    return const AgreementState();
+  }
+
+  /// 서버에서 현재 동의 상태를 조회하여 체크박스 초기값을 채운다.
+  ///
+  /// 실패 시 기본값(전부 false)을 유지하여 사용자가 직접 체크하고 진행할 수
+  /// 있도록 폴백한다. 진입 시 1회만 실행되는 초기화이므로 별도 재시도 UI는
+  /// 두지 않고, 디버그 로그만 남긴다.
+  Future<void> _loadInitial({required bool Function() isDisposed}) async {
+    try {
+      final repo = ref.read(userRepositoryProvider);
+      final status = await repo.getAgreements();
+      if (isDisposed()) return;
+      state = state.copyWith(
+        termsOfService: status.termsOfService,
+        privacyPolicy: status.privacyPolicy,
+        locationTerms: status.locationTerms,
+        marketing: status.marketing,
+        isLoading: false,
+      );
+      debugPrint('✅ [AgreementNotifier] 초기 동의 상태 로드 성공');
+    } catch (e) {
+      if (isDisposed()) return;
+      // 폴백: 전부 미체크 상태로 둠. UI는 체크박스가 활성화되어 사용자가
+      // 직접 체크하여 진행할 수 있다.
+      state = state.copyWith(isLoading: false);
+      debugPrint('⚠️ [AgreementNotifier] 초기 동의 상태 로드 실패: $e (전부 미체크 폴백)');
+    }
+  }
+
+  // 초기 로드/제출 중에는 체크박스 변경을 무시한다.
+  // 비동기 응답이 사용자 토글을 덮어쓰지 않도록 isLoading도 가드한다.
+  // 동의 이력의 정합성을 지키기 위해 토글·일괄설정 모두 동일하게 가드한다.
   void toggleTerms() {
-    if (state.isSubmitting) return;
+    if (state.isLoading || state.isSubmitting) return;
     state = state.copyWith(termsOfService: !state.termsOfService);
   }
 
   void togglePrivacy() {
-    if (state.isSubmitting) return;
+    if (state.isLoading || state.isSubmitting) return;
     state = state.copyWith(privacyPolicy: !state.privacyPolicy);
   }
 
   void toggleLocation() {
-    if (state.isSubmitting) return;
+    if (state.isLoading || state.isSubmitting) return;
     state = state.copyWith(locationTerms: !state.locationTerms);
   }
 
   void toggleMarketing() {
-    if (state.isSubmitting) return;
+    if (state.isLoading || state.isSubmitting) return;
     state = state.copyWith(marketing: !state.marketing);
   }
 
   /// 4개를 일괄 [value]로 설정
   void toggleAll(bool value) {
-    if (state.isSubmitting) return;
+    if (state.isLoading || state.isSubmitting) return;
     state = state.copyWith(
       termsOfService: value,
       privacyPolicy: value,
@@ -101,7 +147,9 @@ class AgreementNotifier extends _$AgreementNotifier {
   /// - [AgreementSubmitResult.failure]: API 에러 — [lastError] 확인 후 스낵바
   /// - [AgreementSubmitResult.success]: 성공 — 호출자가 AuthNotifier 갱신 필요
   Future<AgreementSubmitResult> submit() async {
-    if (state.isSubmitting) return AgreementSubmitResult.failure;
+    if (state.isLoading || state.isSubmitting) {
+      return AgreementSubmitResult.failure;
+    }
     if (!state.hasAllRequired) return AgreementSubmitResult.missingRequired;
 
     lastError = null;

--- a/lib/features/auth/presentation/providers/agreement_provider.freezed.dart
+++ b/lib/features/auth/presentation/providers/agreement_provider.freezed.dart
@@ -21,6 +21,7 @@ mixin _$AgreementState {
   bool get privacyPolicy => throw _privateConstructorUsedError;
   bool get locationTerms => throw _privateConstructorUsedError;
   bool get marketing => throw _privateConstructorUsedError;
+  bool get isLoading => throw _privateConstructorUsedError;
   bool get isSubmitting => throw _privateConstructorUsedError;
 
   /// Create a copy of AgreementState
@@ -42,6 +43,7 @@ abstract class $AgreementStateCopyWith<$Res> {
     bool privacyPolicy,
     bool locationTerms,
     bool marketing,
+    bool isLoading,
     bool isSubmitting,
   });
 }
@@ -65,6 +67,7 @@ class _$AgreementStateCopyWithImpl<$Res, $Val extends AgreementState>
     Object? privacyPolicy = null,
     Object? locationTerms = null,
     Object? marketing = null,
+    Object? isLoading = null,
     Object? isSubmitting = null,
   }) {
     return _then(
@@ -84,6 +87,10 @@ class _$AgreementStateCopyWithImpl<$Res, $Val extends AgreementState>
             marketing: null == marketing
                 ? _value.marketing
                 : marketing // ignore: cast_nullable_to_non_nullable
+                      as bool,
+            isLoading: null == isLoading
+                ? _value.isLoading
+                : isLoading // ignore: cast_nullable_to_non_nullable
                       as bool,
             isSubmitting: null == isSubmitting
                 ? _value.isSubmitting
@@ -109,6 +116,7 @@ abstract class _$$AgreementStateImplCopyWith<$Res>
     bool privacyPolicy,
     bool locationTerms,
     bool marketing,
+    bool isLoading,
     bool isSubmitting,
   });
 }
@@ -131,6 +139,7 @@ class __$$AgreementStateImplCopyWithImpl<$Res>
     Object? privacyPolicy = null,
     Object? locationTerms = null,
     Object? marketing = null,
+    Object? isLoading = null,
     Object? isSubmitting = null,
   }) {
     return _then(
@@ -151,6 +160,10 @@ class __$$AgreementStateImplCopyWithImpl<$Res>
             ? _value.marketing
             : marketing // ignore: cast_nullable_to_non_nullable
                   as bool,
+        isLoading: null == isLoading
+            ? _value.isLoading
+            : isLoading // ignore: cast_nullable_to_non_nullable
+                  as bool,
         isSubmitting: null == isSubmitting
             ? _value.isSubmitting
             : isSubmitting // ignore: cast_nullable_to_non_nullable
@@ -169,6 +182,7 @@ class _$AgreementStateImpl extends _AgreementState
     this.privacyPolicy = false,
     this.locationTerms = false,
     this.marketing = false,
+    this.isLoading = true,
     this.isSubmitting = false,
   }) : super._();
 
@@ -186,11 +200,14 @@ class _$AgreementStateImpl extends _AgreementState
   final bool marketing;
   @override
   @JsonKey()
+  final bool isLoading;
+  @override
+  @JsonKey()
   final bool isSubmitting;
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'AgreementState(termsOfService: $termsOfService, privacyPolicy: $privacyPolicy, locationTerms: $locationTerms, marketing: $marketing, isSubmitting: $isSubmitting)';
+    return 'AgreementState(termsOfService: $termsOfService, privacyPolicy: $privacyPolicy, locationTerms: $locationTerms, marketing: $marketing, isLoading: $isLoading, isSubmitting: $isSubmitting)';
   }
 
   @override
@@ -202,6 +219,7 @@ class _$AgreementStateImpl extends _AgreementState
       ..add(DiagnosticsProperty('privacyPolicy', privacyPolicy))
       ..add(DiagnosticsProperty('locationTerms', locationTerms))
       ..add(DiagnosticsProperty('marketing', marketing))
+      ..add(DiagnosticsProperty('isLoading', isLoading))
       ..add(DiagnosticsProperty('isSubmitting', isSubmitting));
   }
 
@@ -218,6 +236,8 @@ class _$AgreementStateImpl extends _AgreementState
                 other.locationTerms == locationTerms) &&
             (identical(other.marketing, marketing) ||
                 other.marketing == marketing) &&
+            (identical(other.isLoading, isLoading) ||
+                other.isLoading == isLoading) &&
             (identical(other.isSubmitting, isSubmitting) ||
                 other.isSubmitting == isSubmitting));
   }
@@ -229,6 +249,7 @@ class _$AgreementStateImpl extends _AgreementState
     privacyPolicy,
     locationTerms,
     marketing,
+    isLoading,
     isSubmitting,
   );
 
@@ -250,6 +271,7 @@ abstract class _AgreementState extends AgreementState {
     final bool privacyPolicy,
     final bool locationTerms,
     final bool marketing,
+    final bool isLoading,
     final bool isSubmitting,
   }) = _$AgreementStateImpl;
   const _AgreementState._() : super._();
@@ -262,6 +284,8 @@ abstract class _AgreementState extends AgreementState {
   bool get locationTerms;
   @override
   bool get marketing;
+  @override
+  bool get isLoading;
   @override
   bool get isSubmitting;
 

--- a/lib/features/auth/presentation/providers/agreement_provider.g.dart
+++ b/lib/features/auth/presentation/providers/agreement_provider.g.dart
@@ -6,13 +6,18 @@ part of 'agreement_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$agreementNotifierHash() => r'da209d1ffe60b660911edcea70ba2fb645fab390';
+String _$agreementNotifierHash() => r'08dc74430481c78c6d2ac9e3b02093468ebf49f4';
 
 /// 약관 동의 화면 전용 Notifier
 ///
 /// 체크박스 상태 관리 + `PUT /api/user/agreements` 제출을 담당합니다.
 /// 제출 성공 시 AuthNotifier의 requiresAgreement를 false로 갱신하는 책임은
 /// 호출자(AgreementPage)가 담당합니다 (Provider 간 강결합 회피).
+///
+/// [build] 진입 시 `GET /api/user/agreements`를 호출하여 서버에 저장된
+/// 현재 동의 상태로 체크박스를 초기화합니다. 백엔드가 정책 갱신으로 특정
+/// 약관만 false로 되돌리는 경우, 이미 동의한 약관은 체크된 상태로 표시되어
+/// 사용자가 변경된 약관만 새로 체크하면 되도록 합니다.
 ///
 /// Copied from [AgreementNotifier].
 @ProviderFor(AgreementNotifier)

--- a/lib/features/game/presentation/providers/game_event_provider.g.dart
+++ b/lib/features/game/presentation/providers/game_event_provider.g.dart
@@ -47,7 +47,7 @@ final gameSystemApiProvider = AutoDisposeProvider<GameSystemApi>.internal(
 @Deprecated('Will be removed in 3.0. Use Ref instead')
 // ignore: unused_element
 typedef GameSystemApiRef = AutoDisposeProviderRef<GameSystemApi>;
-String _$gameEventNotifierHash() => r'0eb12eb4b73f39be5244f235e57f7ba2330687c4';
+String _$gameEventNotifierHash() => r'93e2703cc718ec6880a92fef278fb0b4875e7438';
 
 /// 게임 이벤트 상태 관리 Notifier
 ///

--- a/test/features/auth/presentation/providers/agreement_provider_test.dart
+++ b/test/features/auth/presentation/providers/agreement_provider_test.dart
@@ -25,6 +25,14 @@ class _FakeConnectivity implements Connectivity {
 }
 
 class _FakeUserRepository implements UserRepository {
+  // build() 진입 시 호출되는 GET /api/user/agreements의 가짜 응답.
+  // 기본값은 모두 false — 기존 테스트는 "체크박스가 비어있는 상태에서 시작"을 가정.
+  AgreementStatusEntity getAgreementsResult = const AgreementStatusEntity(
+    termsOfService: false,
+    privacyPolicy: false,
+    locationTerms: false,
+    marketing: false,
+  );
   bool? lastMarketing;
   Object? errorToThrow;
   int callCount = 0;
@@ -37,17 +45,31 @@ class _FakeUserRepository implements UserRepository {
   }
 
   @override
-  Future<AgreementStatusEntity> getAgreements() => throw UnimplementedError();
+  Future<AgreementStatusEntity> getAgreements() async => getAgreementsResult;
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// build() 안의 `Future.microtask(_loadInitial)`이 완료될 때까지 대기한다.
+///
+/// 초기 로드는 다음과 같은 비동기 chain을 거친다:
+///   1) Future.microtask로 _loadInitial 진입
+///   2) await repo.getAgreements()   (fake도 async라 microtask 한 번 더)
+///   3) state.copyWith(...) 적용
+///
+/// nested microtask가 모두 비워지도록 여러 iteration yield한다.
+Future<void> _flushInitialLoad() async {
+  for (var i = 0; i < 5; i++) {
+    await Future<void>.delayed(Duration.zero);
+  }
 }
 
 ProviderContainer _makeContainer({
   required Connectivity connectivity,
   required UserRepository userRepository,
 }) {
-  return ProviderContainer(
+  final container = ProviderContainer(
     overrides: [
       connectivityServiceProvider.overrideWith(
         (ref) => ConnectivityService(connectivity),
@@ -55,16 +77,25 @@ ProviderContainer _makeContainer({
       userRepositoryProvider.overrideWith((ref) => userRepository),
     ],
   );
+  // @riverpod는 기본 autoDispose. read만 하면 read 사이 dispose되어
+  // state(copyWith로 갱신한 값)가 초기화될 수 있다. 명시적 listener를 두어
+  // 테스트 전반에 걸쳐 Notifier 인스턴스가 살아있도록 한다.
+  // container.dispose()로 listener도 함께 정리되므로 subscription은 보관 불필요.
+  container.listen<AgreementState>(agreementNotifierProvider, (_, _) {});
+  return container;
 }
 
 void main() {
   group('AgreementNotifier — 초기 상태', () {
-    test('모든 체크박스는 초기에 false이다', () {
+    test('서버 응답이 모두 false면 초기 체크박스도 모두 false이다', () async {
       final container = _makeContainer(
         connectivity: _FakeConnectivity(true),
         userRepository: _FakeUserRepository(),
       );
       addTearDown(container.dispose);
+
+      container.read(agreementNotifierProvider);
+      await _flushInitialLoad();
 
       final state = container.read(agreementNotifierProvider);
       expect(state.termsOfService, false);
@@ -72,12 +103,61 @@ void main() {
       expect(state.locationTerms, false);
       expect(state.marketing, false);
       expect(state.hasAllRequired, false);
+      expect(state.isLoading, false);
       expect(state.isSubmitting, false);
+    });
+
+    test('서버에 이미 동의된 약관은 체크된 상태로 초기화된다', () async {
+      // 시나리오: 백엔드가 위치정보 약관만 v2로 갱신하여 locationTerms=false로 내려보냄.
+      // 사용자는 이미 동의한 이용약관·개인정보는 체크된 상태로 봐야 한다.
+      final fakeRepo = _FakeUserRepository()
+        ..getAgreementsResult = const AgreementStatusEntity(
+          termsOfService: true,
+          privacyPolicy: true,
+          locationTerms: false,
+          marketing: true,
+        );
+      final container = _makeContainer(
+        connectivity: _FakeConnectivity(true),
+        userRepository: fakeRepo,
+      );
+      addTearDown(container.dispose);
+
+      container.read(agreementNotifierProvider);
+      await _flushInitialLoad();
+
+      final state = container.read(agreementNotifierProvider);
+      expect(state.termsOfService, true);
+      expect(state.privacyPolicy, true);
+      expect(state.locationTerms, false);
+      expect(state.marketing, true);
+      expect(state.hasAllRequired, false);
+      expect(state.isLoading, false);
+    });
+
+    test('초기 로드 실패 시 모두 미체크 + isLoading=false로 폴백한다', () async {
+      final fakeRepo = _FakeUserRepository();
+      // getAgreements()가 예외를 던지도록 override (subclass 없이 손쉽게 익명 fake로).
+      final container = _makeContainer(
+        connectivity: _FakeConnectivity(true),
+        userRepository: _ThrowingUserRepository(fakeRepo),
+      );
+      addTearDown(container.dispose);
+
+      container.read(agreementNotifierProvider);
+      await _flushInitialLoad();
+
+      final state = container.read(agreementNotifierProvider);
+      expect(state.termsOfService, false);
+      expect(state.privacyPolicy, false);
+      expect(state.locationTerms, false);
+      expect(state.marketing, false);
+      expect(state.isLoading, false);
     });
   });
 
   group('AgreementNotifier — toggle', () {
-    test('toggleTerms는 termsOfService만 뒤집는다', () {
+    test('toggleTerms는 termsOfService만 뒤집는다', () async {
       final container = _makeContainer(
         connectivity: _FakeConnectivity(true),
         userRepository: _FakeUserRepository(),
@@ -85,6 +165,7 @@ void main() {
       addTearDown(container.dispose);
 
       final notifier = container.read(agreementNotifierProvider.notifier);
+      await _flushInitialLoad();
       notifier.toggleTerms();
 
       final state = container.read(agreementNotifierProvider);
@@ -94,7 +175,36 @@ void main() {
       expect(state.marketing, false);
     });
 
-    test('toggleAll(true)는 4개를 모두 true로, toggleAll(false)는 모두 false로 만든다', () {
+    test(
+      'toggleAll(true)는 4개를 모두 true로, toggleAll(false)는 모두 false로 만든다',
+      () async {
+        final container = _makeContainer(
+          connectivity: _FakeConnectivity(true),
+          userRepository: _FakeUserRepository(),
+        );
+        addTearDown(container.dispose);
+
+        final notifier = container.read(agreementNotifierProvider.notifier);
+        await _flushInitialLoad();
+        notifier.toggleAll(true);
+
+        var state = container.read(agreementNotifierProvider);
+        expect(state.termsOfService, true);
+        expect(state.privacyPolicy, true);
+        expect(state.locationTerms, true);
+        expect(state.marketing, true);
+        expect(state.allAgreed, true);
+
+        notifier.toggleAll(false);
+        state = container.read(agreementNotifierProvider);
+        expect(state.termsOfService, false);
+        expect(state.privacyPolicy, false);
+        expect(state.locationTerms, false);
+        expect(state.marketing, false);
+      },
+    );
+
+    test('hasAllRequired는 필수 3종이 모두 true일 때만 true이다', () async {
       final container = _makeContainer(
         connectivity: _FakeConnectivity(true),
         userRepository: _FakeUserRepository(),
@@ -102,31 +212,7 @@ void main() {
       addTearDown(container.dispose);
 
       final notifier = container.read(agreementNotifierProvider.notifier);
-      notifier.toggleAll(true);
-
-      var state = container.read(agreementNotifierProvider);
-      expect(state.termsOfService, true);
-      expect(state.privacyPolicy, true);
-      expect(state.locationTerms, true);
-      expect(state.marketing, true);
-      expect(state.allAgreed, true);
-
-      notifier.toggleAll(false);
-      state = container.read(agreementNotifierProvider);
-      expect(state.termsOfService, false);
-      expect(state.privacyPolicy, false);
-      expect(state.locationTerms, false);
-      expect(state.marketing, false);
-    });
-
-    test('hasAllRequired는 필수 3종이 모두 true일 때만 true이다', () {
-      final container = _makeContainer(
-        connectivity: _FakeConnectivity(true),
-        userRepository: _FakeUserRepository(),
-      );
-      addTearDown(container.dispose);
-
-      final notifier = container.read(agreementNotifierProvider.notifier);
+      await _flushInitialLoad();
       notifier.toggleTerms();
       notifier.togglePrivacy();
 
@@ -136,6 +222,26 @@ void main() {
       notifier.toggleLocation();
       state = container.read(agreementNotifierProvider);
       expect(state.hasAllRequired, true);
+    });
+
+    test('초기 로드 중에는 toggle이 무시된다', () {
+      // _flushInitialLoad()를 일부러 호출하지 않아 isLoading=true 상태에서 토글 시도.
+      final container = _makeContainer(
+        connectivity: _FakeConnectivity(true),
+        userRepository: _FakeUserRepository(),
+      );
+      addTearDown(container.dispose);
+
+      final notifier = container.read(agreementNotifierProvider.notifier);
+      notifier.toggleTerms();
+      notifier.toggleAll(true);
+
+      final state = container.read(agreementNotifierProvider);
+      expect(state.isLoading, true);
+      expect(state.termsOfService, false);
+      expect(state.privacyPolicy, false);
+      expect(state.locationTerms, false);
+      expect(state.marketing, false);
     });
   });
 
@@ -149,6 +255,7 @@ void main() {
       addTearDown(container.dispose);
 
       final notifier = container.read(agreementNotifierProvider.notifier);
+      await _flushInitialLoad();
       notifier.toggleAll(true);
 
       final result = await notifier.submit();
@@ -167,6 +274,7 @@ void main() {
       addTearDown(container.dispose);
 
       final notifier = container.read(agreementNotifierProvider.notifier);
+      await _flushInitialLoad();
       notifier.toggleTerms();
       notifier.togglePrivacy();
 
@@ -185,6 +293,7 @@ void main() {
       addTearDown(container.dispose);
 
       final notifier = container.read(agreementNotifierProvider.notifier);
+      await _flushInitialLoad();
       notifier.toggleAll(true);
 
       final result = await notifier.submit();
@@ -204,6 +313,7 @@ void main() {
       addTearDown(container.dispose);
 
       final notifier = container.read(agreementNotifierProvider.notifier);
+      await _flushInitialLoad();
       notifier.toggleAll(true);
 
       final result = await notifier.submit();
@@ -213,4 +323,23 @@ void main() {
       expect(container.read(agreementNotifierProvider).isSubmitting, false);
     });
   });
+}
+
+/// getAgreements()만 예외를 던지는 fake (초기 로드 실패 폴백 테스트용)
+class _ThrowingUserRepository implements UserRepository {
+  _ThrowingUserRepository(this._delegate);
+
+  final UserRepository _delegate;
+
+  @override
+  Future<AgreementStatusEntity> getAgreements() async {
+    throw const ServerException(message: 'simulated');
+  }
+
+  @override
+  Future<void> updateAgreements({required bool marketing}) =>
+      _delegate.updateAgreements(marketing: marketing);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }


### PR DESCRIPTION
- AgreementNotifier.build() 진입 시 GET /api/user/agreements 호출하여 서버 동의 상태로 체크박스 초기화
- 백엔드가 일부 약관만 false로 갱신한 경우, 이미 동의한 약관은 체크된 상태로 표시
- isLoading 가드 추가: 초기 로드 중 toggle/submit이 응답을 덮어쓰지 못하도록 차단
- 로드 실패 시 전부 미체크로 폴백, 사용자가 직접 체크하여 진행 가능
- 테스트: 초기 로드 시나리오 3건(정상/이미 동의/실패 폴백) + isLoading 가드 1건 추가

## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->


## ✅ 테스트
---

- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 약관 동의 페이지에서 초기 서버 로드 중 사용자 입력이 덮어써지는 문제 해결
  * 초기 로드 중 동의하기 버튼이 비활성화되도록 개선
  * 체크박스 상태 변경 시 서버 응답이 덮어쓰지 않도록 수정

* **Tests**
  * 약관 동의 기능 관련 테스트 케이스 확대

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cops-and-robbers/cops-and-robbers-FE/pull/374?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->