### PR TITLE
fix : Fastlane 배포 시 multi_json 누락 수정 #410

### DIFF
--- a/.github/workflows/PROJECT-FLUTTER-ANDROID-PLAYSTORE-CICD.yaml
+++ b/.github/workflows/PROJECT-FLUTTER-ANDROID-PLAYSTORE-CICD.yaml
@@ -562,7 +562,7 @@ jobs:
       # Fastlane 설치 (Bundler 방식으로 CFPropertyList 의존성 충돌 방지)
       - name: Install Fastlane
         run: |
-          printf 'source "https://rubygems.org"\ngem "fastlane"\n' > Gemfile
+          printf 'source "https://rubygems.org"\ngem "fastlane"\ngem "multi_json"\n' > Gemfile
           bundle install
           echo "✅ Fastlane 설치 완료"
           bundle exec fastlane --version

--- a/.github/workflows/PROJECT-FLUTTER-IOS-TESTFLIGHT.yaml
+++ b/.github/workflows/PROJECT-FLUTTER-IOS-TESTFLIGHT.yaml
@@ -480,7 +480,7 @@ jobs:
       # Fastlane 설치 (Bundler 방식으로 CFPropertyList 의존성 충돌 방지)
       - name: Install Fastlane
         run: |
-          printf 'source "https://rubygems.org"\ngem "fastlane"\n' > Gemfile
+          printf 'source "https://rubygems.org"\ngem "fastlane"\ngem "multi_json"\n' > Gemfile
           bundle install
           echo "✅ Fastlane 설치 완료"
           bundle exec fastlane --version

--- a/android/Gemfile
+++ b/android/Gemfile
@@ -4,3 +4,8 @@ source "https://rubygems.org"
 
 # Fastlane - Android 빌드 자동화
 gem "fastlane", "~> 2.225"
+
+# multi_json - fastlane 액션(create_app_on_managed_play_store → google-apis →
+# representable)이 런타임에 require하지만, signet/googleauth가 더 이상 transitive
+# 의존으로 끌어오지 않아 직접 명시해야 번들에서 누락되지 않음
+gem "multi_json"

--- a/ios/Gemfile
+++ b/ios/Gemfile
@@ -7,3 +7,8 @@ gem "fastlane", "~> 2.225"
 
 # CocoaPods - iOS 의존성 관리
 gem "cocoapods", "~> 1.15"
+
+# multi_json - fastlane 액션(create_app_on_managed_play_store → google-apis →
+# representable)이 런타임에 require하지만, signet/googleauth가 더 이상 transitive
+# 의존으로 끌어오지 않아 직접 명시해야 번들에서 누락되지 않음
+gem "multi_json"


### PR DESCRIPTION
- Android/iOS Gemfile에 gem "multi_json" 추가
- 배포 워크플로우 동적 Gemfile에 multi_json 명시
- signet/googleauth가 더 이상 transitive 의존으로 끌어오지 않아 직접 선언

## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->


## ✅ 테스트
---

- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료
