### PR TITLE
feat : 대기방 QR 코드를 딥링크 URL로 전환 #417

### DIFF
--- a/lib/core/deeplink/deeplink_constants.dart
+++ b/lib/core/deeplink/deeplink_constants.dart
@@ -1,0 +1,15 @@
+/// 딥링크 / App Links / Universal Links 관련 상수.
+///
+/// 초대 링크 생성(`share_util`)과 수신 파싱(`deeplink_event`, 홈 QR 스캐너)이
+/// 동일한 host 를 공유하도록 단일 소스로 둔다.
+///
+/// ⚠️ 네이티브 설정과 반드시 함께 변경해야 한다 — 아래 두 파일은 빌드타임
+/// 설정이라 이 Dart 상수를 참조할 수 없으므로, host 변경 시 수동 동기화 필수:
+///   - android/app/src/main/AndroidManifest.xml  (App Links intent-filter: android:host)
+///   - ios/Runner/Runner.entitlements             (Universal Links: applinks:)
+class DeeplinkConstants {
+  DeeplinkConstants._();
+
+  /// App Links(Android) / Universal Links(iOS) 공개 host.
+  static const String host = 'copsnro66ers.site';
+}

--- a/lib/core/deeplink/deeplink_event.dart
+++ b/lib/core/deeplink/deeplink_event.dart
@@ -1,5 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import 'deeplink_constants.dart';
+
 part 'deeplink_event.freezed.dart';
 
 /// 딥링크 URI 를 의미 있는 sealed event 로 normalize.
@@ -26,8 +28,8 @@ sealed class DeeplinkEvent with _$DeeplinkEvent {
       return DeeplinkEvent.unknown(uri: uri);
     }
 
-    // https App Links / Universal Links: https://copsnro66ers.site/join/{inviteCode}
-    const allowedHosts = {'copsnro66ers.site'};
+    // https App Links / Universal Links: https://{host}/join/{inviteCode}
+    const allowedHosts = {DeeplinkConstants.host};
     if (!allowedHosts.contains(uri.host)) {
       return DeeplinkEvent.unknown(uri: uri);
     }

--- a/lib/core/utils/share_util.dart
+++ b/lib/core/utils/share_util.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:share_plus/share_plus.dart';
 
+import '../deeplink/deeplink_constants.dart';
+
 /// 텍스트를 네이티브 공유 시트로 공유하는 유틸리티
 ///
 /// OS 기본 공유 시트를 열어 [text]를 다른 앱으로 공유합니다.
@@ -14,6 +16,14 @@ Future<void> shareText(String text, {String? subject}) async {
   }
 }
 
+/// 초대 코드를 방 참가 딥링크 URL 로 변환.
+///
+/// `https://{host}/join/{code}` 형태이며, 공유 메시지와 대기방 QR 이 같은 형식을
+/// 쓰도록 단일 소스로 둔다. host 는 딥링크 파서/스캐너와 [DeeplinkConstants.host]
+/// 를 공유하므로 항상 일치한다.
+String buildInviteDeeplink(String code) =>
+    'https://${DeeplinkConstants.host}/join/$code';
+
 /// 초대 코드를 딥링크 URL 과 함께 공유.
 ///
 /// `"{shareMessage}\nhttps://copsnro66ers.site/join/{code}"` 형태로 OS 공유 시트 호출.
@@ -21,6 +31,5 @@ Future<void> shareText(String text, {String? subject}) async {
 ///
 /// 호출 측이 i18n 메시지를 전달해서 ARB 키를 한 곳에서 관리하지 않아도 되게 함.
 Future<void> shareInviteCode(String code, String shareMessage) async {
-  final url = 'https://copsnro66ers.site/join/$code';
-  await shareText('$shareMessage\n$url');
+  await shareText('$shareMessage\n${buildInviteDeeplink(code)}');
 }

--- a/lib/features/session/presentation/pages/home_page.dart
+++ b/lib/features/session/presentation/pages/home_page.dart
@@ -11,6 +11,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../../../core/deeplink/deeplink_constants.dart';
 import '../../../../core/i18n/error_message_mapper.dart';
 import '../../../../core/network/dio_exception_handler.dart';
 import '../../../../core/utils/agreement_error_handler.dart';
@@ -512,11 +513,11 @@ class _HomePageState extends ConsumerState<HomePage> {
                 builder: (_) => QrScannerPage<String>(
                   title: l10n.dialogScanInviteQrTitle,
                   onParse: (rawValue) {
-                    // 1) 딥링크 URL 형식 (https://copsnro66ers.site/join/{code}) 우선 파싱.
+                    // 1) 딥링크 URL 형식 (https://{host}/join/{code}) 우선 파싱.
                     // 경로는 정확히 /join/{code}만 허용하고, 결과는 대문자로 정규화해
                     // 수동 입력 경로(toUpperCase)와 동작을 일치시킨다.
                     final uri = Uri.tryParse(rawValue);
-                    if (uri != null && uri.host == 'copsnro66ers.site') {
+                    if (uri != null && uri.host == DeeplinkConstants.host) {
                       final segments = uri.pathSegments;
                       if (segments.length == 2 &&
                           segments[0] == 'join' &&

--- a/lib/features/session/presentation/pages/waiting_room_page.dart
+++ b/lib/features/session/presentation/pages/waiting_room_page.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -1200,13 +1198,13 @@ class _WaitingRoomPageState extends ConsumerState<WaitingRoomPage>
           mainAxisSize: MainAxisSize.min,
           children: [
             // QR 코드 이미지
-            // 초대코드 JSON 인코딩 — 앱 내 QR 스캐너 (home_page 의 _showJoinRoomDialogInternal)
-            // 가 같은 자리 친구 빠른 입장에 사용. 카톡 등 원격 공유는 별도 공유 버튼이 딥링크 URL 을
-            // 전송하므로 QR 까지 URL 로 만들 필요는 없다.
+            // 딥링크 URL 인코딩 (share_util 의 공유 버튼과 동일 형식).
+            // 앱 내 QR 스캐너는 URL 뒤 초대코드를 파싱해 입장하고, 일반 카메라로
+            // 촬영하면 딥링크로 앱이 실행돼 자동 참가한다.
             ClipRRect(
               borderRadius: AppRadius.xxlarge,
               child: QrImageView(
-                data: jsonEncode({'inviteCode': code}),
+                data: buildInviteDeeplink(code),
                 version: QrVersions.auto,
                 size: 220.w,
                 backgroundColor: isDark ? AppColors.white : AppColors.black100,


### PR DESCRIPTION
- 대기방 QR 데이터를 JSON에서 딥링크 URL로 변경 (일반 카메라 스캔 시 자동 참가)
- 딥링크 URL 생성 로직을 buildInviteDeeplink 함수로 추출
- 도메인 host를 DeeplinkConstants.host 상수로 단일화 (생성/파서/스캐너 공유)

## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->


## ✅ 테스트
---

- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료
